### PR TITLE
UI enhancements in screensaver view

### DIFF
--- a/app/src/main/java/nl/giejay/android/tv/immich/album/AlbumDetailsFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/album/AlbumDetailsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.navigation.fragment.findNavController
 import arrow.core.Either
+import com.zeuskartik.mediaslider.DisplayOptions
 import com.zeuskartik.mediaslider.MediaSliderConfiguration
 import nl.giejay.android.tv.immich.api.ApiClient
 import nl.giejay.android.tv.immich.api.model.AlbumDetails
@@ -18,6 +19,7 @@ import nl.giejay.android.tv.immich.shared.prefs.LiveSharedPreferences
 import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
 import nl.giejay.android.tv.immich.shared.util.toCard
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
+import java.util.EnumSet
 
 
 class AlbumDetailsFragment : VerticalCardGridFragment<Asset>() {
@@ -66,13 +68,18 @@ class AlbumDetailsFragment : VerticalCardGridFragment<Asset>() {
 
     override fun onItemClicked(card: Card) {
         // todo find a better way to pass data to other fragment without using the Intent extras (possibly too large)
+        val displayOptions: EnumSet<DisplayOptions> = EnumSet.noneOf(DisplayOptions::class.java);
+        if (PreferenceManager.screensaverShowDescription()) {
+            displayOptions += DisplayOptions.TITLE
+        }
+        if (PreferenceManager.screensaverShowMediaCount()) {
+            displayOptions += DisplayOptions.MEDIA_COUNT
+        }
         LocalStorage.mediaSliderItems = assets.toSliderItems()
         findNavController().navigate(
             AlbumDetailsFragmentDirections.actionDetailsToPhotoSlider(
                 MediaSliderConfiguration(
-                    PreferenceManager.sliderShowDescription(),
-                    PreferenceManager.sliderShowMediaCount(),
-                    false,
+                    displayOptions,
                     currentAlbum!!.albumName,
                     "",
                     "",

--- a/app/src/main/java/nl/giejay/android/tv/immich/album/AlbumFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/album/AlbumFragment.kt
@@ -26,13 +26,10 @@ class AlbumFragment : VerticalCardGridFragment<Album>() {
 
     override fun sortItems(items: List<Album>): List<Album> {
         return if (selectionMode) {
-            items.sortedWith { b, a ->
-                compareValuesBy(
-                    a,
-                    b,
-                    { PreferenceManager.getScreenSaverAlbums().contains(it.id) },
-                    { it.endDate })
-            }
+            val sorted = items.sortedWith(PreferenceManager.albumsOrder().sort)
+            val selected = sorted.filter { PreferenceManager.getScreenSaverAlbums().contains(it.id) }
+            val unselected = sorted.filter { !selected.contains(it) }
+            selected + unselected
         } else {
             items.sortedWith(PreferenceManager.albumsOrder().sort)
         }

--- a/app/src/main/java/nl/giejay/android/tv/immich/api/ApiClient.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/api/ApiClient.kt
@@ -8,6 +8,7 @@ import nl.giejay.android.tv.immich.api.model.Asset
 import nl.giejay.android.tv.immich.api.model.SearchRequest
 import nl.giejay.android.tv.immich.api.service.ApiService
 import nl.giejay.android.tv.immich.api.util.ApiUtil.executeAPICall
+import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
@@ -46,7 +47,13 @@ class ApiClient(private val config: ApiClientConfig) {
     }
 
     suspend fun listAssetsFromAlbum(albumId: String): Either<String, AlbumDetails> {
-        return executeAPICall(200) { service.listAssetsFromAlbum(albumId) }
+        return executeAPICall(200) {
+            val response = service.listAssetsFromAlbum(albumId)
+            val album = response.body()
+            val assets = album!!.assets.map{ Asset(it.id, it.type, it.deviceAssetId, it.exifInfo, it.fileModifiedAt, album.albumName)}
+            val updatedAlbum = AlbumDetails(album.albumName, album.description, album.id, album.albumThumbnailAssetId, assets)
+            Response.success(updatedAlbum)
+        }
     }
 
     suspend fun listAssets(page: Int, pageCount: Int, order: String): Either<String, List<Asset>> {

--- a/app/src/main/java/nl/giejay/android/tv/immich/api/model/Asset.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/api/model/Asset.kt
@@ -12,5 +12,6 @@ data class Asset(
     val type: String,
     val deviceAssetId: String?,
     val exifInfo: AssetExifInfo?,
-    val fileModifiedAt: Date?
+    val fileModifiedAt: Date?,
+    val albumName: String?
 )

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/AllAssetFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/AllAssetFragment.kt
@@ -2,6 +2,7 @@ package nl.giejay.android.tv.immich.assets
 
 import androidx.navigation.fragment.findNavController
 import arrow.core.Either
+import com.zeuskartik.mediaslider.DisplayOptions
 import com.zeuskartik.mediaslider.MediaSliderConfiguration
 import nl.giejay.android.tv.immich.api.ApiClient
 import nl.giejay.android.tv.immich.api.util.ApiUtil
@@ -14,6 +15,7 @@ import nl.giejay.android.tv.immich.shared.prefs.PhotosOrder
 import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
 import nl.giejay.android.tv.immich.shared.util.toCard
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
+import java.util.EnumSet
 
 class AllAssetFragment : VerticalCardGridFragment<Asset>() {
     override fun sortItems(items: List<Asset>): List<Asset> {
@@ -33,13 +35,18 @@ class AllAssetFragment : VerticalCardGridFragment<Asset>() {
     }
 
     override fun onItemClicked(card: Card) {
+        val displayOptions: EnumSet<DisplayOptions> = EnumSet.noneOf(DisplayOptions::class.java);
+        if (PreferenceManager.screensaverShowDescription()) {
+            displayOptions += DisplayOptions.TITLE
+        }
+        if (PreferenceManager.screensaverShowMediaCount()) {
+            displayOptions += DisplayOptions.MEDIA_COUNT
+        }
         LocalStorage.mediaSliderItems = assets.toSliderItems()
         findNavController().navigate(
             HomeFragmentDirections.actionHomeFragmentToPhotoSlider(
                 MediaSliderConfiguration(
-                    PreferenceManager.sliderShowDescription(),
-                    PreferenceManager.sliderShowMediaCount(),
-                    false,
+                    displayOptions,
                     "",
                     "",
                     "",

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/PreferenceManager.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/PreferenceManager.kt
@@ -19,6 +19,10 @@ object PreferenceManager {
     private val KEY_SCREENSAVER_INTERVAL = "screensaver_interval"
     private val KEY_SCREENSAVER_SHOW_MEDIA_COUNT = "screensaver_show_media_count"
     private val KEY_SCREENSAVER_SHOW_DESCRIPTION = "screensaver_show_description"
+    private val KEY_SCREENSAVER_SHOW_ALBUM_NAME = "screensaver_show_album_name"
+    private val KEY_SCREENSAVER_SHOW_DATE = "screensaver_show_date"
+    private val KEY_SCREENSAVER_SHOW_CLOCK = "screensaver_show_clock"
+    private val KEY_SCREENSAVER_ANIMATE_ASSET_SLIDE = "screensaver_animate_asset_slide"
     private val KEY_SCREENSAVER_ALBUMS = "screensaver_albums"
     private val KEY_SCREENSAVER_INCLUDE_VIDEOS = "screensaver_include_videos"
     private val KEY_SCREENSAVER_VIDEO_SOUND = "screensaver_play_sound"
@@ -47,6 +51,10 @@ object PreferenceManager {
         KEY_SLIDER_SHOW_DESCRIPTION to true,
         KEY_SLIDER_SHOW_MEDIA_COUNT to true,
         KEY_SCREENSAVER_SHOW_DESCRIPTION to true,
+        KEY_SCREENSAVER_SHOW_ALBUM_NAME to true,
+        KEY_SCREENSAVER_SHOW_DATE to true,
+        KEY_SCREENSAVER_SHOW_CLOCK to true,
+        KEY_SCREENSAVER_ANIMATE_ASSET_SLIDE to true,
         KEY_SCREENSAVER_SHOW_MEDIA_COUNT to true,
         KEY_SCREENSAVER_ALBUMS to mutableSetOf<String>(),
         KEY_SCREENSAVER_INCLUDE_VIDEOS to false,
@@ -88,6 +96,22 @@ object PreferenceManager {
 
     fun screensaverShowMediaCount(): Boolean {
         return liveContext[KEY_SCREENSAVER_SHOW_MEDIA_COUNT] as Boolean
+    }
+
+    fun screensaverShowAlbumName(): Boolean {
+        return liveContext[KEY_SCREENSAVER_SHOW_ALBUM_NAME] as Boolean
+    }
+
+    fun screensaverShowDate(): Boolean {
+        return liveContext[KEY_SCREENSAVER_SHOW_DATE] as Boolean
+    }
+
+    fun screensaverShowClock(): Boolean {
+        return liveContext[KEY_SCREENSAVER_SHOW_CLOCK] as Boolean
+    }
+
+    fun screensaverAnimateAssetSlide(): Boolean {
+        return liveContext[KEY_SCREENSAVER_ANIMATE_ASSET_SLIDE] as Boolean
     }
 
     fun screensaverIncludeVideos(): Boolean {

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/util/AssetUtil.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/util/AssetUtil.kt
@@ -11,7 +11,9 @@ fun List<Asset>.toSliderItems(): List<SliderItem> {
         SliderItem(
             ApiUtil.getFileUrl(it.id),
             SliderItemType.valueOf(it.type.uppercase()),
-            it.exifInfo?.description?.ifEmpty { it.deviceAssetId } ?: it.deviceAssetId,
+            it.exifInfo?.description,
+            it.albumName,
+            it.exifInfo?.dateTimeOriginal,
             ApiUtil.getThumbnailUrl(it.id, "preview")
         )
     }

--- a/app/src/main/res/xml/preferences_screensaver.xml
+++ b/app/src/main/res/xml/preferences_screensaver.xml
@@ -31,6 +31,18 @@
             android:summary="Show description of asset in screensaver"/>
 
         <CheckBoxPreference
+            android:key="screensaver_show_album_name"
+            android:title="Show album name"
+            android:defaultValue="true"
+            android:summary="Show album name of asset in screensaver"/>
+
+        <CheckBoxPreference
+            android:key="screensaver_show_date"
+            android:title="Show date"
+            android:defaultValue="true"
+            android:summary="Show date of asset in screensaver"/>
+
+        <CheckBoxPreference
             android:key="screensaver_show_media_count"
             android:title="Show media count"
             android:defaultValue="true"
@@ -45,6 +57,18 @@
             android:key="screensaver_play_sound"
             android:title="Play sound"
             android:summary="Play sound of videos during screensaver"/>
+
+        <CheckBoxPreference
+            android:key="screensaver_show_clock"
+            android:title="Show clock"
+            android:defaultValue="true"
+            android:summary="Show clock in screensaver"/>
+
+        <CheckBoxPreference
+            android:key="screensaver_animate_asset_slide"
+            android:title="Slide the new asset in"
+            android:defaultValue="true"
+            android:summary="Slide the new asset in when transitioning"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Hi,

I don't know if this is of any interest to you, but I wanted to make some changes to how the screensaver shows my photos on my TV. Please feel free to merge or ignore. (There is an associated Pull Request with the changed for MediaSliderView.)

Summary of changes:
* Moved the text to the bottom of the screen
* Changed the font and font colour
* Added a gradient scrim to make sure text is visible without interfering too much with the photo
* Added a 'subtitle' to the display - this is used to display the album name
* Allowed the 'description'/EXIF text to take up to 2 lines
* Added the image date
* Added a clock
* Added the option to stop the next screensaver image sliding in
* Added preference options to toggle new text features
* Moved to an EnumSet for display options instead of booleans

In additions, the following small miscellaneous changes were made (not really worth an individual Pull Request):
* Explicitly randomise the first album chosen instead of taking the first in the Set
* Sort the selected albums according to the sort choice (selected are still first, but are sorted, followed by unselected sorted)