### PR TITLE
Quick fix for issue #88 : menu broken on old devices (api 25)

### DIFF
--- a/app/src/main/res/layout/presenter_row.xml
+++ b/app/src/main/res/layout/presenter_row.xml
@@ -14,5 +14,9 @@
     <TextView android:id="@+id/tvTitle"
         android:layout_width="match_parent"
         android:textSize="20sp"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        />
 </LinearLayout>


### PR DESCRIPTION
This is a quick workaround:  TextView made focusable and clickable.
It doesn't fix the font size of the TextView, the missing methods and other warnings in the logs, 
but it seems good enough to make it work on some old devices.

Thanks for the amazing app!
