### PR TITLE
Bug fix: App not showing on app list of MiBox.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,8 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.HOME" />
             </intent-filter>
 
             <intent-filter>


### PR DESCRIPTION
Currently the app is not showing on the app list of MiBox when install with the APK file.
Adding following lines in manifest to support that:
```
<category android:name="android.intent.category.LAUNCHER" />
<category android:name="android.intent.category.HOME" />
```