### PR TITLE
Add longer slideshow options

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -8,6 +8,9 @@
         <item>20 seconds</item>
         <item>30 seconds</item>
         <item>1 minute</item>
+        <item>3 minutes</item>
+        <item>5 minutes</item>
+        <item>10 minutes</item>
     </array>
     <string-array name="interval_values">
         <item>1</item>
@@ -17,6 +20,9 @@
         <item>20</item>
         <item>30</item>
         <item>60</item>
+        <item>180</item>
+        <item>300</item>
+        <item>600</item>
     </string-array>
 
     <array name="meta_data_alignment_labels">


### PR DESCRIPTION
Love the app!

My Android TV normally has ambient slideshow options of 10s, 30s, 1m, 3m, 5m, and 10m. Of these, I typically use 5m or 10m. This PR simply adds the longer options (3m, 5m, and 10m).