### PR TITLE
Feature: Ken Burns zoom and pan effect, and scroll panorama in slideshow

### DIFF
--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
@@ -21,6 +21,8 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_PAN_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_EFFECT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
 import nl.giejay.android.tv.immich.shared.util.toCard
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
@@ -102,7 +104,9 @@ class FolderFragment : VerticalCardGridFragment<Item>() {
                         enableSlideAnimation = PreferenceManager.get(SCREENSAVER_ANIMATE_ASSET_SLIDE),
                         gradiantOverlay = false,
                         metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.VIEWER),
-                        zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS)
+                        zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS),
+                        zoomEffectPercent = PreferenceManager.get(SLIDER_ZOOM_EFFECT),
+                        panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT)
                     )
                 )
             )

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
@@ -3,7 +3,6 @@ package nl.giejay.android.tv.immich.assets
 import androidx.navigation.fragment.findNavController
 import arrow.core.Either
 import arrow.core.getOrElse
-import nl.giejay.mediaslider.model.MetaDataType
 import kotlinx.coroutines.launch
 import nl.giejay.android.tv.immich.album.AlbumDetailsFragmentDirections
 import nl.giejay.android.tv.immich.api.ApiClient
@@ -26,7 +25,6 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
 import nl.giejay.android.tv.immich.shared.util.toCard
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
 import nl.giejay.mediaslider.config.MediaSliderConfiguration
-import java.util.EnumSet
 
 data class Item(val item: Any) {
     fun isAsset() = item is Asset

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
@@ -22,6 +22,7 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
 import nl.giejay.android.tv.immich.shared.util.toCard
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
 import nl.giejay.mediaslider.config.MediaSliderConfiguration
@@ -102,7 +103,8 @@ class FolderFragment : VerticalCardGridFragment<Item>() {
                         debugEnabled = PreferenceManager.get(DEBUG_MODE),
                         enableSlideAnimation = PreferenceManager.get(SCREENSAVER_ANIMATE_ASSET_SLIDE),
                         gradiantOverlay = false,
-                        metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.VIEWER)
+                        metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.VIEWER),
+                        zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS)
                     )
                 )
             )

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
@@ -24,6 +24,8 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_PAN_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_EFFECT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
 import nl.giejay.android.tv.immich.shared.util.toCard
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
@@ -107,7 +109,9 @@ abstract class GenericAssetFragment : VerticalCardGridFragment<Asset>() {
                     enableSlideAnimation = PreferenceManager.get(SCREENSAVER_ANIMATE_ASSET_SLIDE),
                     gradiantOverlay = false,
                     metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.VIEWER),
-                    zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS)
+                    zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS),
+                    zoomEffectPercent = PreferenceManager.get(SLIDER_ZOOM_EFFECT),
+                    panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT)
                 )
             )
         )

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
@@ -24,6 +24,7 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
 import nl.giejay.android.tv.immich.shared.util.toCard
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
 import nl.giejay.mediaslider.util.LoadMore
@@ -105,7 +106,8 @@ abstract class GenericAssetFragment : VerticalCardGridFragment<Asset>() {
                     debugEnabled = PreferenceManager.get(DEBUG_MODE),
                     enableSlideAnimation = PreferenceManager.get(SCREENSAVER_ANIMATE_ASSET_SLIDE),
                     gradiantOverlay = false,
-                    metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.VIEWER)
+                    metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.VIEWER),
+                    zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS)
                 )
             )
         )

--- a/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
@@ -47,6 +47,7 @@ import nl.giejay.mediaslider.util.MediaSliderListener
 import nl.giejay.mediaslider.view.MediaSliderView
 import timber.log.Timber
 import nl.giejay.android.tv.immich.R
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
 import java.util.EnumSet
 
 class ScreenSaverService : DreamService(), MediaSliderListener {
@@ -200,7 +201,8 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
                     debugEnabled = PreferenceManager.get(DEBUG_MODE),
                     enableSlideAnimation = PreferenceManager.get(SCREENSAVER_ANIMATE_ASSET_SLIDE),
                     gradiantOverlay = true,
-                    metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.SCREENSAVER)
+                    metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.SCREENSAVER),
+                    zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS)
                 )
             )
             mediaSliderView.toggleSlideshow(false)

--- a/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
@@ -7,13 +7,12 @@ import android.widget.Toast
 import androidx.media3.datasource.DefaultHttpDataSource
 import arrow.core.Either
 import arrow.core.getOrElse
-import nl.giejay.mediaslider.model.MetaDataType
-import nl.giejay.mediaslider.config.MediaSliderConfiguration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import nl.giejay.android.tv.immich.R
 import nl.giejay.android.tv.immich.api.ApiClient
 import nl.giejay.android.tv.immich.api.ApiClientConfig
 import nl.giejay.android.tv.immich.api.model.AlbumDetails
@@ -30,25 +29,19 @@ import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ANIMATE_ASSET_SLIDE
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_INCLUDE_VIDEOS
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_INTERVAL
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_PLAY_SOUND
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_SHOW_ALBUM_NAME
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_SHOW_CLOCK
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_SHOW_DATE
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_SHOW_DESCRIPTION
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_SHOW_MEDIA_COUNT
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_TYPE
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ANIMATION_SPEED
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_GLIDE_TRANSFORMATION
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
+import nl.giejay.mediaslider.config.MediaSliderConfiguration
 import nl.giejay.mediaslider.util.LoadMore
 import nl.giejay.mediaslider.util.MediaSliderListener
 import nl.giejay.mediaslider.view.MediaSliderView
 import timber.log.Timber
-import nl.giejay.android.tv.immich.R
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
-import java.util.EnumSet
 
 class ScreenSaverService : DreamService(), MediaSliderListener {
     private val ioScope = CoroutineScope(Job() + Dispatchers.IO)
@@ -217,8 +210,8 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
         private const val PAGE_COUNT = 100
     }
 
-    override fun onButtonPressed(event: KeyEvent): Boolean {
-        if((event.keyCode == KeyEvent.KEYCODE_DPAD_CENTER || event.keyCode == KeyEvent.KEYCODE_ENTER) && !mediaSliderView.isControllerVisible()){
+    override fun onButtonPressed(keyEvent: KeyEvent): Boolean {
+        if((keyEvent.keyCode == KeyEvent.KEYCODE_DPAD_CENTER || keyEvent.keyCode == KeyEvent.KEYCODE_ENTER) && !mediaSliderView.isControllerVisible()){
             finish()
             return true
         }

--- a/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
@@ -35,6 +35,8 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_GLIDE_TRANSFORMATION
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_PAN_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_EFFECT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
 import nl.giejay.mediaslider.config.MediaSliderConfiguration
@@ -195,7 +197,9 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
                     enableSlideAnimation = PreferenceManager.get(SCREENSAVER_ANIMATE_ASSET_SLIDE),
                     gradiantOverlay = true,
                     metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.SCREENSAVER),
-                    zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS)
+                    zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS),
+                    zoomEffectPercent = PreferenceManager.get(SLIDER_ZOOM_EFFECT),
+                    panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT)
                 )
             )
             mediaSliderView.toggleSlideshow(false)

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
@@ -165,6 +165,13 @@ data object SLIDER_GLIDE_TRANSFORMATION : EnumPref<GlideTransformations>(GlideTr
     }
 }
 data object SLIDER_ZOOM_SCROLL_PANORAMAS : BooleanPref(false, ImmichApplication.appContext!!.getString(R.string.zoom_scroll_panoramas), ImmichApplication.appContext!!.getString(R.string.zoom_scroll_panoramas_desc))
+data object SLIDER_ZOOM_EFFECT : IntSeekbarPref(100,
+    ImmichApplication.appContext!!.getString(R.string.zoom_effect_percent),
+    ImmichApplication.appContext!!.getString(R.string.zoom_effect_percent_desc))
+data object SLIDER_PAN_EFFECT : IntSeekbarPref(100,
+    ImmichApplication.appContext!!.getString(R.string.pan_effect_percent),
+    ImmichApplication.appContext!!.getString(R.string.pan_effect_percent_desc))
+
 data object SLIDER_FORCE_ORIGINAL_VIDEO : BooleanPref(false, ImmichApplication.appContext!!.getString(R.string.force_original_video), ImmichApplication.appContext!!.getString(R.string.force_original_video_desc))
 
 // other
@@ -327,6 +334,8 @@ data object ViewPrefScreen : PrefScreen(ImmichApplication.appContext!!.getString
             SLIDER_FORCE_ORIGINAL_VIDEO,
             SLIDER_MERGE_PORTRAIT_PHOTOS,
             SLIDER_ZOOM_SCROLL_PANORAMAS,
+            SLIDER_ZOOM_EFFECT,
+            SLIDER_PAN_EFFECT,
             SLIDER_METADATA_CUSTOMIZER,
             SLIDER_INTERVAL,
             SLIDER_ANIMATION_SPEED,

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
@@ -164,7 +164,7 @@ data object SLIDER_GLIDE_TRANSFORMATION : EnumPref<GlideTransformations>(GlideTr
         return GlideTransformations.valueOfSafe(prefValue, defaultValue)
     }
 }
-
+data object SLIDER_ZOOM_SCROLL_PANORAMAS : BooleanPref(false, ImmichApplication.appContext!!.getString(R.string.zoom_scroll_panoramas), ImmichApplication.appContext!!.getString(R.string.zoom_scroll_panoramas_desc))
 data object SLIDER_FORCE_ORIGINAL_VIDEO : BooleanPref(false, ImmichApplication.appContext!!.getString(R.string.force_original_video), ImmichApplication.appContext!!.getString(R.string.force_original_video_desc))
 
 // other
@@ -326,6 +326,7 @@ data object ViewPrefScreen : PrefScreen(ImmichApplication.appContext!!.getString
             SLIDER_ONLY_USE_THUMBNAILS,
             SLIDER_FORCE_ORIGINAL_VIDEO,
             SLIDER_MERGE_PORTRAIT_PHOTOS,
+            SLIDER_ZOOM_SCROLL_PANORAMAS,
             SLIDER_METADATA_CUSTOMIZER,
             SLIDER_INTERVAL,
             SLIDER_ANIMATION_SPEED,

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
@@ -165,10 +165,10 @@ data object SLIDER_GLIDE_TRANSFORMATION : EnumPref<GlideTransformations>(GlideTr
     }
 }
 data object SLIDER_ZOOM_SCROLL_PANORAMAS : BooleanPref(false, ImmichApplication.appContext!!.getString(R.string.zoom_scroll_panoramas), ImmichApplication.appContext!!.getString(R.string.zoom_scroll_panoramas_desc))
-data object SLIDER_ZOOM_EFFECT : IntSeekbarPref(100,
+data object SLIDER_ZOOM_EFFECT : IntSeekbarPref(50,
     ImmichApplication.appContext!!.getString(R.string.zoom_effect_percent),
     ImmichApplication.appContext!!.getString(R.string.zoom_effect_percent_desc))
-data object SLIDER_PAN_EFFECT : IntSeekbarPref(100,
+data object SLIDER_PAN_EFFECT : IntSeekbarPref(50,
     ImmichApplication.appContext!!.getString(R.string.pan_effect_percent),
     ImmichApplication.appContext!!.getString(R.string.pan_effect_percent_desc))
 

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/util/AssetUtil.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/util/AssetUtil.kt
@@ -119,16 +119,19 @@ private fun formatDate(date: Date): String {
 
 fun Asset.isPortraitImage(): Boolean {
     val aspectRatio = this.getAspectRatio()
-    return (this.exifInfo?.orientation == 6 || this.exifInfo?.orientation == 8 || (aspectRatio > 0.56 && aspectRatio <= 1.1)) && this.type == SliderItemType.IMAGE.toString()
+    return (this.exifInfo?.orientation == 6 || this.exifInfo?.orientation == 8 || (aspectRatio != null && aspectRatio > 0.56 && aspectRatio <= 1.1)) && this.type == SliderItemType.IMAGE.toString()
 }
 
 fun Asset.isPanoramaImage(): Boolean {
     val aspectRatio = this.getAspectRatio()
-    return ((aspectRatio <= 0.56 || aspectRatio > 2.0)) && this.type == SliderItemType.IMAGE.toString()
+    return (aspectRatio != null && (aspectRatio <= 0.56 || aspectRatio > 2.0)) && this.type == SliderItemType.IMAGE.toString()
 }
 
-fun Asset.getAspectRatio(): Double {
-    return (this.exifInfo?.exifImageWidth?.toDouble() ?: 1.0) / (if ((this.exifInfo?.exifImageHeight ?: 1) > 0) this.exifInfo?.exifImageHeight?.toDouble() ?: 1.0 else 1.0)
+fun Asset.getAspectRatio(): Double? {
+    return if(this.exifInfo != null && this.exifInfo.exifImageHeight != null && this.exifInfo.exifImageWidth != null && this.exifInfo.exifImageHeight > 0)
+        this.exifInfo.exifImageWidth.toDouble() / this.exifInfo.exifImageHeight.toDouble()
+    else
+        null
 }
 
 fun List<Asset>.toCards(): List<Card> {

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/util/AssetUtil.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/util/AssetUtil.kt
@@ -119,7 +119,7 @@ private fun formatDate(date: Date): String {
 
 fun Asset.isPortraitImage(): Boolean {
     val aspectRatio = this.getAspectRatio()
-    return (this.exifInfo?.orientation == 6 || this.exifInfo?.orientation == 8 || (aspectRatio > 0.56 && aspectRatio <= 1.0)) && this.type == SliderItemType.IMAGE.toString()
+    return (this.exifInfo?.orientation == 6 || this.exifInfo?.orientation == 8 || (aspectRatio > 0.56 && aspectRatio <= 1.1)) && this.type == SliderItemType.IMAGE.toString()
 }
 
 fun Asset.isPanoramaImage(): Boolean {
@@ -128,7 +128,7 @@ fun Asset.isPanoramaImage(): Boolean {
 }
 
 fun Asset.getAspectRatio(): Double {
-    return (this.exifInfo?.exifImageWidth?.toDouble() ?: 1.0) / (this.exifInfo?.exifImageHeight?.toDouble() ?: 1.0)
+    return (this.exifInfo?.exifImageWidth?.toDouble() ?: 1.0) / (if ((this.exifInfo?.exifImageHeight ?: 1) > 0) this.exifInfo?.exifImageHeight?.toDouble() ?: 1.0 else 1.0)
 }
 
 fun List<Asset>.toCards(): List<Card> {

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/util/AssetUtil.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/util/AssetUtil.kt
@@ -92,7 +92,8 @@ fun Asset.toSliderItem(): SliderItem {
             MetaDataType.CAMERA to (listOf(this.exifInfo?.make, this.exifInfo?.model)).filterNotNull().joinToString(" "))
             .mapValues { StaticMetaDataProvider(it.value) } +
                 mapOf(MetaDataType.ALBUM_NAME to AlbumMetaDataProvider(this.id)),
-        ApiUtil.getThumbnailUrl(this.id, "preview"))
+        ApiUtil.getThumbnailUrl(this.id, "preview"),
+        this.isPanoramaImage())
 }
 
 private fun formatDate(date: Date): String {
@@ -117,7 +118,17 @@ private fun formatDate(date: Date): String {
 }
 
 fun Asset.isPortraitImage(): Boolean {
-    return (this.exifInfo?.orientation == 6 || (this.exifInfo?.exifImageWidth != null && this.exifInfo.exifImageHeight != null && this.exifInfo.exifImageWidth - 100 < this.exifInfo.exifImageHeight)) && this.type == SliderItemType.IMAGE.toString()
+    val aspectRatio = this.getAspectRatio()
+    return (this.exifInfo?.orientation == 6 || this.exifInfo?.orientation == 8 || (aspectRatio > 0.56 && aspectRatio <= 1.0)) && this.type == SliderItemType.IMAGE.toString()
+}
+
+fun Asset.isPanoramaImage(): Boolean {
+    val aspectRatio = this.getAspectRatio()
+    return ((aspectRatio <= 0.56 || aspectRatio > 2.0)) && this.type == SliderItemType.IMAGE.toString()
+}
+
+fun Asset.getAspectRatio(): Double {
+    return (this.exifInfo?.exifImageWidth?.toDouble() ?: 1.0) / (this.exifInfo?.exifImageHeight?.toDouble() ?: 1.0)
 }
 
 fun List<Asset>.toCards(): List<Card> {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -146,7 +146,7 @@
     <string name="force_original_video">Принудительно оригинальное видео</string>
     <string name="force_original_video_desc">Воспроизводить оригинальное видео, даже если доступна транскодированная версия</string>
     <string name="zoom_scroll_panoramas">Панорамы с увеличением и прокруткой</string>
-    <string name="zoom_scroll_panoramas_desc">Автоматически увеличивайте панорамные фотографии, чтобы заполнить экран, и прокручивайте снизу вверх или справа налево.</string>
+    <string name="zoom_scroll_panoramas_desc">Автоматически увеличивайте панорамные фотографии, чтобы заполнить экран, и прокручивайте снизу вверх или слева направо.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Фото в альбомах</string>
@@ -188,15 +188,15 @@
 
     <!-- Auth step 2 (GuidedStep) -->
     <string name="login_immich_description">Войдите на ваш сервер Immich или попробуйте демо.</string>
-    <string name="server_url_hint">URL сервера (http[s]://...)</string>
+    <string name="server_url_hint">URL сервера (http[s]://…)</string>
     <string name="disable_ssl_verification">Отключить проверку SSL</string>
     <string name="disable_ssl_verification_desc">Используйте это только при проблемах с самоподписанными сертификатами!</string>
     <string name="debug_mode">Режим отладки</string>
     <string name="debug_mode_desc">Включите это, если у вас возникают проблемы с получением данных Immich.</string>
     <string name="submit">Отправить</string>
-    <string name="enter_server_url">Введите URL сервера (https://...)</string>
+    <string name="enter_server_url">Введите URL сервера (https://…)</string>
     <string name="enter_api_key">Введите API-ключ; если уже ввели, попробуйте снова выделить его и нажать Enter/OK, а не Назад</string>
-    <string name="enter_valid_server_url">Введите корректный URL сервера (https://...)</string>
+    <string name="enter_valid_server_url">Введите корректный URL сервера (https://…)</string>
 
     <!-- Auth by phone errors and messages -->
     <string name="or_enter_code_on_auth_url">Или введите код %1$s на %2$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -146,11 +146,11 @@
     <string name="force_original_video">Принудительно оригинальное видео</string>
     <string name="force_original_video_desc">Воспроизводить оригинальное видео, даже если доступна транскодированная версия</string>
     <string name="zoom_scroll_panoramas">Эффект увеличения и панорамирования</string>
-    <string name="zoom_scroll_panoramas_desc">Во время слайд-шоу применяйте эффекты Кена Бернса, такие как эффекты увеличения и панорамирования, для фотостраниц, не относящихся к портретам. Автоматически увеличивайте панорамные фотографии, чтобы заполнить экран, и прокручивайте снизу вверх или слева направо.</string>
+    <string name="zoom_scroll_panoramas_desc">Во время слайд-шоу применяйте эффекты увеличения и панорамирования для отдельных страниц фотографии. Автоматически увеличивайте панорамные фотографии, чтобы заполнить экран, и прокручивайте снизу вверх или слева направо.</string>
     <string name="zoom_effect_percent">Величина эффекта увеличения %</string>
-    <string name="zoom_effect_percent_desc">Регулируйте силу эффекта увеличения на проценты.</string>
+    <string name="zoom_effect_percent_desc">Регулировка силы эффекта увеличения.</string>
     <string name="pan_effect_percent">Количество эффекта Пан %</string>
-    <string name="pan_effect_percent_desc">Отрегулируйте силу панорамирования на проценты.</string>
+    <string name="pan_effect_percent_desc">Отрегулируйте силу панорамирования.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Фото в альбомах</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -147,6 +147,10 @@
     <string name="force_original_video_desc">Воспроизводить оригинальное видео, даже если доступна транскодированная версия</string>
     <string name="zoom_scroll_panoramas">Эффект увеличения и панорамирования</string>
     <string name="zoom_scroll_panoramas_desc">Во время слайд-шоу применяйте эффекты Кена Бернса, такие как эффекты увеличения и панорамирования, для фотостраниц, не относящихся к портретам. Автоматически увеличивайте панорамные фотографии, чтобы заполнить экран, и прокручивайте снизу вверх или слева направо.</string>
+    <string name="zoom_effect_percent">Величина эффекта увеличения %</string>
+    <string name="zoom_effect_percent_desc">Регулируйте силу эффекта увеличения на проценты.</string>
+    <string name="pan_effect_percent">Количество эффекта Пан %</string>
+    <string name="pan_effect_percent_desc">Отрегулируйте силу панорамирования на проценты.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Фото в альбомах</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -145,6 +145,8 @@
     <string name="photo_transformation_desc">Преобразование фото</string>
     <string name="force_original_video">Принудительно оригинальное видео</string>
     <string name="force_original_video_desc">Воспроизводить оригинальное видео, даже если доступна транскодированная версия</string>
+    <string name="zoom_scroll_panoramas">Панорамы с увеличением и прокруткой</string>
+    <string name="zoom_scroll_panoramas_desc">Автоматически увеличивайте панорамные фотографии, чтобы заполнить экран, и прокручивайте снизу вверх или справа налево.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Фото в альбомах</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -145,8 +145,8 @@
     <string name="photo_transformation_desc">Преобразование фото</string>
     <string name="force_original_video">Принудительно оригинальное видео</string>
     <string name="force_original_video_desc">Воспроизводить оригинальное видео, даже если доступна транскодированная версия</string>
-    <string name="zoom_scroll_panoramas">Панорамы с увеличением и прокруткой</string>
-    <string name="zoom_scroll_panoramas_desc">Автоматически увеличивайте панорамные фотографии, чтобы заполнить экран, и прокручивайте снизу вверх или слева направо.</string>
+    <string name="zoom_scroll_panoramas">Эффект увеличения и панорамирования</string>
+    <string name="zoom_scroll_panoramas_desc">Во время слайд-шоу применяйте эффекты Кена Бернса, такие как эффекты увеличения и панорамирования, для фотостраниц, не относящихся к портретам. Автоматически увеличивайте панорамные фотографии, чтобы заполнить экран, и прокручивайте снизу вверх или слева направо.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Фото в альбомах</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,6 +146,8 @@
     <string name="photo_transformation_desc">Photo transformation</string>
     <string name="force_original_video">Force original video</string>
     <string name="force_original_video_desc">Play original video, even when transcode is available</string>
+    <string name="zoom_scroll_panoramas">Zoom and scroll panoramas</string>
+    <string name="zoom_scroll_panoramas_desc">Automatically zoom panorama photos to fill the screen and scroll top-to-bottom or left-to-right.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Photos in albums</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,7 +147,7 @@
     <string name="force_original_video">Force original video</string>
     <string name="force_original_video_desc">Play original video, even when transcode is available</string>
     <string name="zoom_scroll_panoramas">Zoom and scroll panoramas</string>
-    <string name="zoom_scroll_panoramas_desc">Automatically zoom panorama photos to fill the screen and scroll top-to-bottom or left-to-right.</string>
+    <string name="zoom_scroll_panoramas_desc">Automatically zoom panorama photos to fill the screen and scroll bottom-to-top or right-to-left.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Photos in albums</string>
@@ -189,15 +189,15 @@
 
     <!-- Auth step 2 (GuidedStep) -->
     <string name="login_immich_description">Login to your Immich server or try a demo.</string>
-    <string name="server_url_hint">Server URL (http[s]://...)</string>
+    <string name="server_url_hint">Server URL (http[s]://…)</string>
     <string name="disable_ssl_verification">Disable SSL verification</string>
-    <string name="disable_ssl_verification_desc">Only use this when you have issues with self signed certificates!</string>
+    <string name="disable_ssl_verification_desc">Only use this when you have issues with self-signed certificates!</string>
     <string name="debug_mode">Debug mode</string>
     <string name="debug_mode_desc">Enable this if you are experiencing issues with getting the Immich data.</string>
     <string name="submit">Submit</string>
-    <string name="enter_server_url">Please enter a server URL (https://...)</string>
+    <string name="enter_server_url">Please enter a server URL (https://…)</string>
     <string name="enter_api_key">Please enter an API key, if you did enter it, try to highlight it again and press enter/OK, not back (sorry).</string>
-    <string name="enter_valid_server_url">Please enter a valid server URL (https://...)</string>
+    <string name="enter_valid_server_url">Please enter a valid server URL (https://…)</string>
 
     <!-- Auth by phone -->
     <string name="or_enter_code_on_auth_url">Or enter the code %1$s on %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,7 +147,7 @@
     <string name="force_original_video">Force original video</string>
     <string name="force_original_video_desc">Play original video, even when transcode is available</string>
     <string name="zoom_scroll_panoramas">Zoom and scroll panoramas</string>
-    <string name="zoom_scroll_panoramas_desc">Automatically zoom panorama photos to fill the screen and scroll bottom-to-top or right-to-left.</string>
+    <string name="zoom_scroll_panoramas_desc">Automatically zoom panorama photos to fill the screen and scroll bottom-to-top or left-to-right. </string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Photos in albums</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,11 +147,11 @@
     <string name="force_original_video">Force original video</string>
     <string name="force_original_video_desc">Play original video, even when transcode is available</string>
     <string name="zoom_scroll_panoramas">Zoom and Pan Effect</string>
-    <string name="zoom_scroll_panoramas_desc">During Slideshows apply Ken Burns like zoom and pan effects for non-portrait photo pages. Automatically zoom panorama photos to fill the screen and scroll bottom-to-top or left-to-right.</string>
+    <string name="zoom_scroll_panoramas_desc">During Slideshows apply zoom and pan effects for single photo pages. Automatically zoom panorama photos to fill the screen and scroll bottom-to-top or left-to-right.</string>
     <string name="zoom_effect_percent">Zoom Effect Amount %</string>
-    <string name="zoom_effect_percent_desc">Adjust strength of zoom effect by percentage.</string>
+    <string name="zoom_effect_percent_desc">Adjust strength of zoom effect.</string>
     <string name="pan_effect_percent">Pan Effect Amount %</string>
-    <string name="pan_effect_percent_desc">Adjust strength of panning effect by percentage.</string>
+    <string name="pan_effect_percent_desc">Adjust strength of panning effect.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Photos in albums</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,8 +146,8 @@
     <string name="photo_transformation_desc">Photo transformation</string>
     <string name="force_original_video">Force original video</string>
     <string name="force_original_video_desc">Play original video, even when transcode is available</string>
-    <string name="zoom_scroll_panoramas">Zoom and scroll panoramas</string>
-    <string name="zoom_scroll_panoramas_desc">Automatically zoom panorama photos to fill the screen and scroll bottom-to-top or left-to-right. </string>
+    <string name="zoom_scroll_panoramas">Zoom and Pan Effect</string>
+    <string name="zoom_scroll_panoramas_desc">During Slideshows apply Ken Burns like zoom and pan effects for non-portrait photo pages. Automatically zoom panorama photos to fill the screen and scroll bottom-to-top or left-to-right.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Photos in albums</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,10 @@
     <string name="force_original_video_desc">Play original video, even when transcode is available</string>
     <string name="zoom_scroll_panoramas">Zoom and Pan Effect</string>
     <string name="zoom_scroll_panoramas_desc">During Slideshows apply Ken Burns like zoom and pan effects for non-portrait photo pages. Automatically zoom panorama photos to fill the screen and scroll bottom-to-top or left-to-right.</string>
+    <string name="zoom_effect_percent">Zoom Effect Amount %</string>
+    <string name="zoom_effect_percent_desc">Adjust strength of zoom effect by percentage.</string>
+    <string name="pan_effect_percent">Pan Effect Amount %</string>
+    <string name="pan_effect_percent_desc">Adjust strength of panning effect by percentage.</string>
 
     <!-- Other preferences -->
     <string name="photos_in_albums">Photos in albums</string>


### PR DESCRIPTION
Add a new feature to automatically zoom and pan photos, and scroll panorama photos. This effect will run during slideshows and the screen saver.

With a Ken Burns like effect, zoom in or out of single photo pages, which are not panoramas, when slideshow interval is 3 seconds or greater. At 100% strength, randomly zoom the cropped and scaled photo between 1.05 and 3.50 times. Randomly pan 50% of the image width and height. Start from, or return to, the default zoom and photo centre.

The default View Setting Pan and Zoom Strength are 50% to apply the default effect. They can be adjusted up or down to reduce or enhance the effect.

Zoom panoramas to fill the width or height of the screen and scroll from left-to-right or bottom-to-top when running a slideshow with intervals 10 seconds or greater. Panoramas are images with an aspect ratio less than 0.56 or greater than 2.0.