### PR TITLE
Fix original video buffering and stuttering

### DIFF
--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
@@ -16,6 +16,7 @@ import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ANIMATE_ASSET_SLIDE
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ANIMATION_SPEED
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_GLIDE_TRANSFORMATION
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_FORCE_ORIGINAL_VIDEO
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_INTERVAL
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
@@ -106,7 +107,8 @@ class FolderFragment : VerticalCardGridFragment<Item>() {
                         metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.VIEWER),
                         zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS),
                         zoomEffectPercent = PreferenceManager.get(SLIDER_ZOOM_EFFECT),
-                        panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT)
+                        panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
+                        useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO)
                     )
                 )
             )

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
@@ -19,6 +19,7 @@ import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ANIMATE_ASSET_SLIDE
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ANIMATION_SPEED
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_GLIDE_TRANSFORMATION
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_FORCE_ORIGINAL_VIDEO
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_INTERVAL
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
@@ -111,7 +112,8 @@ abstract class GenericAssetFragment : VerticalCardGridFragment<Asset>() {
                     metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.VIEWER),
                     zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS),
                     zoomEffectPercent = PreferenceManager.get(SLIDER_ZOOM_EFFECT),
-                    panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT)
+                    panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
+                    useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO)
                 )
             )
         )

--- a/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
@@ -32,6 +32,7 @@ import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_PLAY_SOUND
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_TYPE
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ANIMATION_SPEED
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_GLIDE_TRANSFORMATION
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_FORCE_ORIGINAL_VIDEO
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
@@ -199,7 +200,8 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
                     metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.SCREENSAVER),
                     zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS),
                     zoomEffectPercent = PreferenceManager.get(SLIDER_ZOOM_EFFECT),
-                    panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT)
+                    panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
+                    useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO)
                 )
             )
             mediaSliderView.toggleSlideshow(false)
@@ -222,4 +224,3 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
         return false
     }
 }
-

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/config/MediaSliderConfiguration.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/config/MediaSliderConfiguration.kt
@@ -25,6 +25,7 @@ class MediaSliderConfiguration : Parcelable {
     val zoomAndScrollPanorama: Boolean
     val zoomEffectPercent: Int
     val panEffectPercent: Int
+    val useLargeVideoBuffer: Boolean
 
     constructor(startPosition: Int,
                 interval: Int,
@@ -43,7 +44,8 @@ class MediaSliderConfiguration : Parcelable {
                 metaDataConfig: List<MetaDataItem>,
                 zoomAndScrollPanorama: Boolean,
                 zoomEffectPercent: Int,
-                panEffectPercent: Int) {
+                panEffectPercent: Int,
+                useLargeVideoBuffer: Boolean = false) {
         this.startPosition = startPosition
         this.interval = interval
         this.isOnlyUseThumbnails = onlyUseThumbnails
@@ -62,6 +64,7 @@ class MediaSliderConfiguration : Parcelable {
         this.zoomAndScrollPanorama = zoomAndScrollPanorama
         this.zoomEffectPercent = zoomEffectPercent
         this.panEffectPercent = panEffectPercent
+        this.useLargeVideoBuffer = useLargeVideoBuffer
     }
 
     private constructor(`in`: Parcel) {
@@ -80,6 +83,7 @@ class MediaSliderConfiguration : Parcelable {
         zoomAndScrollPanorama = `in`.readByte().toInt() != 0
         this.zoomEffectPercent = `in`.readInt()
         this.panEffectPercent = `in`.readInt()
+        this.useLargeVideoBuffer = `in`.readByte().toInt() != 0
     }
 
     val isGradiantOverlayVisible: Boolean
@@ -117,6 +121,7 @@ class MediaSliderConfiguration : Parcelable {
         dest.writeByte((if (zoomAndScrollPanorama) 1 else 0).toByte())
         dest.writeInt(zoomEffectPercent)
         dest.writeInt(panEffectPercent)
+        dest.writeByte((if (useLargeVideoBuffer) 1 else 0).toByte())
     }
 
     companion object {

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/view/ExoPlayerView.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/view/ExoPlayerView.kt
@@ -1,5 +1,6 @@
 package nl.giejay.mediaslider.view
 
+import android.app.ActivityManager
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -44,10 +45,8 @@ class ExoPlayerView @JvmOverloads constructor(context: Context, resourceId: Int,
     ) {
         player = ExoPlayer.Builder(context)
             .setRenderersFactory(renderersFactory)
-            .setLoadControl(DefaultLoadControl.Builder()
-                .setPrioritizeTimeOverSizeThresholds(false)
-                .build()
-            ).build()
+            .setLoadControl(createLoadControl(config))
+            .build()
         playerView.player = player
         if (!config.isVideoSoundEnable) player?.volume = 0f
 
@@ -110,5 +109,45 @@ class ExoPlayerView @JvmOverloads constructor(context: Context, resourceId: Int,
 
     fun isReady(): Boolean {
         return player != null
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun createLoadControl(config: MediaSliderConfiguration): DefaultLoadControl {
+        val builder = DefaultLoadControl.Builder()
+        if (config.useLargeVideoBuffer) {
+            builder
+                .setBufferDurationsMs(
+                    MIN_BUFFER_MS,
+                    MAX_BUFFER_MS,
+                    BUFFER_FOR_PLAYBACK_MS,
+                    BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS
+                )
+                .setTargetBufferBytes(getSafetyBufferBytes())
+                .setPrioritizeTimeOverSizeThresholds(true)
+        } else {
+            builder.setPrioritizeTimeOverSizeThresholds(false)
+        }
+        return builder.build()
+    }
+
+    private fun getSafetyBufferBytes(): Int {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager ?: return DEFAULT_SAFETY_BYTES
+        val memInfo = ActivityManager.MemoryInfo()
+        am.getMemoryInfo(memInfo)
+        val totalMemMb = memInfo.totalMem / (1024 * 1024)
+        val safeMb = (totalMemMb * SAFETY_MEMORY_FRACTION).toInt().coerceIn(MIN_SAFETY_MB, MAX_SAFETY_MB)
+        return safeMb * 1024 * 1024
+    }
+
+    private companion object {
+        const val MIN_BUFFER_MS = 10_000
+        const val MAX_BUFFER_MS = 300_000
+        const val BUFFER_FOR_PLAYBACK_MS = 4_000
+        const val BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS = 4_000
+
+        const val SAFETY_MEMORY_FRACTION = 0.40
+        const val MIN_SAFETY_MB = 384
+        const val MAX_SAFETY_MB = 768
+        const val DEFAULT_SAFETY_BYTES = 512 * 1024 * 1024
     }
 }


### PR DESCRIPTION
Adds a custom ExoPlayer load control when 'force original video' preference is enabled:
  - Time-based thresholds tuned for progressive download (10s/300s min/max)
  - Fast startup (4s) and recovery (4s) for minimal interruption
  - Byte safety cap scaled to device RAM (40%, 384-768MB) to prevent OOM
  - PrioritizeTimeOverSizeThresholds=true keeps TCP pipe hot

Wires useLargeVideoBuffer through MediaSliderConfiguration to FolderFragment, GenericAssetFragment, and ScreenSaverService.