### PR TITLE
Fix 4K60 playback on Chromecast with Google TV (Amlogic BAD_VALUE quirk)

### DIFF
--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/adapter/ScreenSlidePagerAdapter.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/adapter/ScreenSlidePagerAdapter.kt
@@ -14,7 +14,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import com.zeuskartik.mediaslider.R
-import io.github.anilbeesetti.nextlib.media3ext.ffdecoder.NextRenderersFactory
+import nl.giejay.mediaslider.player.AmlogicSafeRenderersFactory
 import nl.giejay.mediaslider.config.MediaSliderConfiguration
 import nl.giejay.mediaslider.model.SliderItem
 import nl.giejay.mediaslider.model.SliderItemType
@@ -73,7 +73,7 @@ class ScreenSlidePagerAdapter(private val context: Context,
             val useTextureView = model.mainItem.orientation != 1 || failedPositions.contains(model.url)
             view = ExoPlayerView(context, if (useTextureView) R.layout.video_item_texture_view else R.layout.video_item)
             view.tag = "view$position"
-            view.setupPlayer(config, NextRenderersFactory(context), exoPlayerListener, buttonListener) { player, error ->
+            view.setupPlayer(config, AmlogicSafeRenderersFactory(context), exoPlayerListener, buttonListener) { player, error ->
                 val shouldRetry = !useTextureView && !failedPositions.contains(model.url)
                 Timber.e(error,
                     "Player error at position $position for url ${model.url}. Already failed: ${failedPositions.contains(model.url)}." +

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/player/AmlogicSafeRenderersFactory.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/player/AmlogicSafeRenderersFactory.kt
@@ -1,0 +1,58 @@
+package nl.giejay.mediaslider.player
+
+import android.content.Context
+import android.os.Handler
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.video.MediaCodecVideoRenderer
+import androidx.media3.exoplayer.video.VideoRendererEventListener
+import io.github.anilbeesetti.nextlib.media3ext.ffdecoder.NextRenderersFactory
+import timber.log.Timber
+
+/**
+ * Same renderers as [NextRenderersFactory] (hardware MediaCodec first, ffmpeg
+ * software decoders as extension), but the stock hardware video renderer is
+ * swapped for [FrameRateClampingVideoRenderer] to survive the Amlogic
+ * "frame rate fractionally above 60 => BAD_VALUE" driver quirk.
+ */
+@UnstableApi
+class AmlogicSafeRenderersFactory(context: Context) : NextRenderersFactory(context) {
+
+    override fun buildVideoRenderers(
+        context: Context,
+        extensionRendererMode: Int,
+        mediaCodecSelector: MediaCodecSelector,
+        enableDecoderFallback: Boolean,
+        eventHandler: Handler,
+        eventListener: VideoRendererEventListener,
+        allowedVideoJoiningTimeMs: Long,
+        out: ArrayList<Renderer>
+    ) {
+        super.buildVideoRenderers(
+            context,
+            extensionRendererMode,
+            mediaCodecSelector,
+            enableDecoderFallback,
+            eventHandler,
+            eventListener,
+            allowedVideoJoiningTimeMs,
+            out
+        )
+        // Replace the exact stock renderer (subclasses like the ffmpeg one are untouched)
+        val index = out.indexOfFirst { it.javaClass == MediaCodecVideoRenderer::class.java }
+        if (index == -1) {
+            Timber.w("Stock MediaCodecVideoRenderer not found, frame rate clamp inactive")
+            return
+        }
+        out[index] = FrameRateClampingVideoRenderer(
+            context,
+            mediaCodecSelector,
+            allowedVideoJoiningTimeMs,
+            enableDecoderFallback,
+            eventHandler,
+            eventListener,
+            MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY
+        )
+    }
+}

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/player/FrameRateClampingVideoRenderer.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/player/FrameRateClampingVideoRenderer.kt
@@ -1,0 +1,75 @@
+package nl.giejay.mediaslider.player
+
+import android.content.Context
+import android.media.MediaFormat
+import android.os.Handler
+import androidx.media3.common.Format
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.video.MediaCodecVideoRenderer
+import androidx.media3.exoplayer.video.VideoRendererEventListener
+import timber.log.Timber
+
+/**
+ * Amlogic decoder drivers (e.g. Chromecast with Google TV, "sabrina") reject
+ * MediaCodec.configure() with BAD_VALUE when the frame rate passed in the
+ * MediaFormat is fractionally above 60 (ExoPlayer derives e.g. 60.000004 from
+ * the sample count / duration of 60 fps recordings). Clamp it back to 60 so
+ * hardware decoding of 4K60 content initializes instead of failing playback.
+ */
+@UnstableApi
+class FrameRateClampingVideoRenderer(
+    context: Context,
+    mediaCodecSelector: MediaCodecSelector,
+    allowedJoiningTimeMs: Long,
+    enableDecoderFallback: Boolean,
+    eventHandler: Handler?,
+    eventListener: VideoRendererEventListener?,
+    maxDroppedFramesToNotify: Int
+) : MediaCodecVideoRenderer(
+    context,
+    mediaCodecSelector,
+    allowedJoiningTimeMs,
+    enableDecoderFallback,
+    eventHandler,
+    eventListener,
+    maxDroppedFramesToNotify
+) {
+    override fun getMediaFormat(
+        format: Format,
+        codecMimeType: String,
+        codecMaxValues: CodecMaxValues,
+        codecOperatingRate: Float,
+        deviceNeedsNoPostProcessWorkaround: Boolean,
+        tunnelingAudioSessionId: Int
+    ): MediaFormat {
+        val mediaFormat = super.getMediaFormat(
+            format,
+            codecMimeType,
+            codecMaxValues,
+            codecOperatingRate,
+            deviceNeedsNoPostProcessWorkaround,
+            tunnelingAudioSessionId
+        )
+        clampFloatKey(mediaFormat, MediaFormat.KEY_FRAME_RATE)
+        clampFloatKey(mediaFormat, MediaFormat.KEY_OPERATING_RATE)
+        return mediaFormat
+    }
+
+    private fun clampFloatKey(mediaFormat: MediaFormat, key: String) {
+        if (!mediaFormat.containsKey(key)) return
+        val value = try {
+            mediaFormat.getFloat(key)
+        } catch (e: ClassCastException) {
+            return // stored as an integer, cannot carry a fractional overshoot
+        }
+        if (value > MAX_SANE_FRAME_RATE && value < MAX_SANE_FRAME_RATE + 1f) {
+            Timber.i("Clamping $key from $value to $MAX_SANE_FRAME_RATE for Amlogic decoder")
+            mediaFormat.setFloat(key, MAX_SANE_FRAME_RATE)
+        }
+    }
+
+    private companion object {
+        const val MAX_SANE_FRAME_RATE = 60f
+    }
+}


### PR DESCRIPTION

## Problem

4K60 videos recorded on phones fail to play on Chromecast 4K with Google TV with
`Cannot play video: MediaCodecVideoRenderer error...`. My whole library of such
recordings (~250 files) was affected, no matter if the server had transcoded
them or not.

## Cause

adb + logcat. ExoPlayer's Mp4Extractor computes the frame rate
from sample count / duration, so a 60fps file comes out as e.g. `60.000004`.
The Amlogic decoder driver on CCwGTV ("sabrina") rejects anything above 60 at
4K during codec configuration:

```
C2VdecComponentIntfImpl: config frame rate:60.000004
CCodecConfig: config failed => BAD_VALUE
MediaCodec: Codec reported err 0xffffffea/BAD_VALUE, actionCode 0, while in state 3/CONFIGURING
MediaCodecRenderer: Failed to initialize decoder: c2.amlogic.hevc.decoder
  java.lang.IllegalArgumentException at android.media.MediaCodec.native_configure

```

Files at 30fps etc. play fine (the driver gets e.g. `30.000004` and takes it -
the check is `fps <= 60` at 4K). Server-side transcoding doesn't help because
the transcode inherits the fractional frame rate.

## Fix

- `FrameRateClampingVideoRenderer` - a `MediaCodecVideoRenderer` subclass that
  overrides `getMediaFormat()` and clamps `KEY_FRAME_RATE` / `KEY_OPERATING_RATE`
  in the `(60, 61)` range back to `60` before the codec is configured.
- `AmlogicSafeRenderersFactory` - extends `NextRenderersFactory`, swaps the stock
  hardware video renderer for the clamping one. The nextlib ffmpeg extension
  renderers are untouched.


The clamp only touches values fractionally above 60, so lower frame rates and
genuinely high-fps content take exactly the same path as before.

## Testing

Chromecast with Google TV 4K, Android 14, app built from this branch. All
previously failing 4K60 HEVC files (originals up to ~80 Mbps and Immich
transcodes ~40 Mbps) now initialize the hardware decoder and play smoothly,
confirmed in logcat (`config frame rate:60.000000`, no decoder errors).
Photos, sub-60fps videos and files that fall back to ffmpeg decoding behave
the same as before the change.
