### PR TITLE
Show partner-shared photos in Timeline (fixes #157)

### DIFF
--- a/app/src/main/java/nl/giejay/android/tv/immich/api/ApiClient.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/api/ApiClient.kt
@@ -22,6 +22,7 @@ import nl.giejay.android.tv.immich.shared.prefs.ContentType
 import nl.giejay.android.tv.immich.shared.prefs.EXCLUDE_ASSETS_IN_ALBUM
 import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
 import nl.giejay.android.tv.immich.shared.prefs.RECENT_ASSETS_MONTHS_BACK
+import nl.giejay.android.tv.immich.shared.prefs.SHOW_PARTNER_PHOTOS_IN_TIMELINE
 import nl.giejay.android.tv.immich.shared.prefs.SIMILAR_ASSETS_PERIOD_DAYS
 import nl.giejay.android.tv.immich.shared.prefs.SIMILAR_ASSETS_YEARS_BACK
 import nl.giejay.android.tv.immich.shared.util.Utils.pmap
@@ -64,6 +65,13 @@ internal fun buildListAssetsSearchRequest(
     // omits it so archived-in-album assets keep showing (VIS-02)
     visibility = if (albumIds.isEmpty()) "timeline" else null
 )
+
+// internal so app/src/test can call it directly without instantiating ApiClient/Retrofit.
+// Server default for withPartners is false/omitted, so only send true when the user opted in -
+// issue #157: partner-shared photos never showed up in the Timeline because this was never wired up.
+internal fun resolveWithPartners(showPartnerPhotosInTimeline: Boolean): Boolean? {
+    return if (showPartnerPhotosInTimeline) true else null
+}
 
 class ApiClient(private val config: ApiClientConfig) {
     companion object ApiClient {
@@ -243,7 +251,9 @@ class ApiClient(private val config: ApiClientConfig) {
     }
 
     suspend fun getTimeBuckets(): Either<String, List<TimeBucketSummary>> =
-        executeAPICall(200) { service.getTimeBuckets() }
+        executeAPICall(200) {
+            service.getTimeBuckets(withPartners = resolveWithPartners(PreferenceManager.get(SHOW_PARTNER_PHOTOS_IN_TIMELINE)))
+        }
 
     /**
      * Fetches all assets for a month bucket.
@@ -252,8 +262,9 @@ class ApiClient(private val config: ApiClientConfig) {
      * omit tags and album membership. Filtering those requires a follow-up ID set cross-check.
      */
     suspend fun getTimeBucket(timeBucket: String): Either<String, List<TimelineAsset>> =
-        executeAPICall(200) { service.getTimeBucket(timeBucket) }
-            .map { it.toTimelineAssets() }
+        executeAPICall(200) {
+            service.getTimeBucket(timeBucket, withPartners = resolveWithPartners(PreferenceManager.get(SHOW_PARTNER_PHOTOS_IN_TIMELINE)))
+        }.map { it.toTimelineAssets() }
 
     /** "On this day" style memories for the current moment (server filters by day-of-year). */
     suspend fun getMemories(): Either<String, List<Memory>> {

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
@@ -251,6 +251,11 @@ data object SLIDER_LOAD_EDITED_PHOTO : BooleanPref(false,
     ImmichApplication.appContext!!.getString(R.string.load_edited_photo),
     ImmichApplication.appContext!!.getString(R.string.load_edited_photo_desc))
 
+// timeline
+data object SHOW_PARTNER_PHOTOS_IN_TIMELINE : BooleanPref(false,
+    ImmichApplication.appContext!!.getString(R.string.show_partner_photos_in_timeline),
+    ImmichApplication.appContext!!.getString(R.string.show_partner_photos_in_timeline_desc))
+
 // other
 data object ALBUMS_SORTING : EnumByTitlePref<AlbumsOrder>(AlbumsOrder.LAST_UPDATED,
     ImmichApplication.appContext!!.getString(R.string.albums),
@@ -485,7 +490,8 @@ data object ViewContentPrefScreen : PrefScreen(ImmichApplication.appContext!!.ge
             SIMILAR_ASSETS_YEARS_BACK,
             SIMILAR_ASSETS_PERIOD_DAYS,
             RECENT_ASSETS_MONTHS_BACK,
-            EXCLUDE_ASSETS_IN_ALBUM
+            EXCLUDE_ASSETS_IN_ALBUM,
+            SHOW_PARTNER_PHOTOS_IN_TIMELINE
         ))
     )
 )

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -80,6 +80,8 @@
     <string name="donate">Faire un don</string>
     <string name="use_hd_thumbnails">Utiliser les miniatures haute résolution</string>
     <string name="use_hd_thumbnails_text">Utiliser les miniatures haute résolution au lieu des images natives/complètes. Cela accélérera considérablement le chargement.</string>
+    <string name="show_partner_photos_in_timeline">Afficher les photos du partenaire dans la chronologie</string>
+    <string name="show_partner_photos_in_timeline_desc">Inclure les photos partagées par votre partenaire dans la chronologie principale, en plus des vues photos et recherche.</string>
     <string name="albums_sorting_text">Définir l’ordre d’affichage des albums</string>
     <string name="order">Ordre</string>
     <string name="photos_sorting_text">Définir l’ordre d’affichage des photos</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -82,6 +82,8 @@
     <string name="donate">Пожертвовать</string>
     <string name="use_hd_thumbnails">Использовать миниатюры высокого разрешения</string>
     <string name="use_hd_thumbnails_text">Использовать миниатюры высокого разрешения вместо полноразмерных изображений. Это значительно ускорит загрузку.</string>
+    <string name="show_partner_photos_in_timeline">Показывать фото партнёра на временной шкале</string>
+    <string name="show_partner_photos_in_timeline_desc">Включить фотографии, которыми поделился ваш партнёр, на основной временной шкале, в дополнение к разделам «Фото» и «Поиск».</string>
     <string name="albums_sorting_text">Задайте порядок отображения альбомов</string>
     <string name="order">Порядок</string>
     <string name="photos_sorting_text">Задайте порядок отображения фотографий</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,8 @@
     <string name="donate">Donate</string>
     <string name="use_hd_thumbnails">Use high resolution thumbnails</string>
     <string name="use_hd_thumbnails_text">Use high resolution thumbnails instead of native/full images. Will dramatically speed up loading.</string>
+    <string name="show_partner_photos_in_timeline">Show partner photos in timeline</string>
+    <string name="show_partner_photos_in_timeline_desc">Include photos shared by your partner in the main timeline, in addition to the photos and search views.</string>
     <string name="albums_sorting_text">Set the order in which albums should appear</string>
     <string name="order">Order</string>
     <string name="photos_sorting_text">Set the order in which photos should appear</string>

--- a/app/src/test/java/nl/giejay/android/tv/immich/api/service/ApiServiceTimelineParamsTest.kt
+++ b/app/src/test/java/nl/giejay/android/tv/immich/api/service/ApiServiceTimelineParamsTest.kt
@@ -1,6 +1,8 @@
 package nl.giejay.android.tv.immich.api.service
 
+import nl.giejay.android.tv.immich.api.resolveWithPartners
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import retrofit2.http.Query
 
@@ -29,5 +31,15 @@ class ApiServiceTimelineParamsTest {
             .map { it.value }
 
         assertEquals(listOf("timeBucket", "order", "visibility", "withPartners"), queryParamNames)
+    }
+
+    // Regression test for issue #157: partner-shared photos never showed up in the Timeline
+    // because ApiClient never passed withPartners, even though ApiService already declared the
+    // query param. resolveWithPartners is what ApiClient.getTimeBuckets/getTimeBucket now call,
+    // wired to the SHOW_PARTNER_PHOTOS_IN_TIMELINE preference.
+    @Test
+    fun `resolveWithPartners sends true only when the preference is enabled`() {
+        assertEquals(true, resolveWithPartners(showPartnerPhotosInTimeline = true))
+        assertNull(resolveWithPartners(showPartnerPhotosInTimeline = false))
     }
 }


### PR DESCRIPTION
## Summary
- `ApiService.getTimeBuckets()` / `getTimeBucket()` already declared `@Query("withPartners")`, but `ApiClient` never passed it, so partner-shared photos only ever showed up in Photos/search, never in Timeline.
- Adds a `SHOW_PARTNER_PHOTOS_IN_TIMELINE` preference (off by default, under View settings → Other) and wires it through both timeline calls via a small `resolveWithPartners()` helper.

Closes #157.

## Test plan
- [x] Extended `ApiServiceTimelineParamsTest` to cover `resolveWithPartners` (true → `true`, false → `null`, matching the server's own default).
- [x] `./gradlew assembleDebug test` — all tests pass except 3 pre-existing failures unrelated to this change (reproduced identically on unmodified `main`: an `ApiUtilTest` assertion and two `FavoriteServiceTest` coroutine-dispatcher failures, both environment-specific, not caused by this diff).
- [x] Verified end-to-end on an actual Nvidia Shield Android TV against a real Immich server: with the toggle on, `timeline/buckets` and `timeline/bucket` requests include `withPartners=true` and partner photos appear in Timeline; with the toggle off, the parameter is omitted (matching current behavior) and partner photos disappear from Timeline again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)