### PR TITLE
Docs: Fix example file paths in build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ When setting up your API key in Immich, make sure to grant the following permiss
 
 1. Clone project with `git clone --recurse git@github.com:giejay/Immich-Android-TV.git`
 2. Create an account at firebase and create a google-services.json file, or
-   `cp apps/google-services.example apps/google-services.json`
-3. copy app/src/strings_other.xml.example to app/src/main/res/values/strings_other.xml and modify
+   `cp app/google-services.example app/google-services.json`
+3. copy app/strings_other.xml.example to app/src/main/res/values/strings_other.xml and modify
    the address and API keys for your demo server.
 4. Build apk with `./gradlew assembleRelease`
 


### PR DESCRIPTION
## Summary

- Fix the path used to copy `google-services.example`.
- Fix the source path for `strings_other.xml.example`.

## Why

The documented source paths do not exist in the repository, so following the build steps as written fails. The corrected paths match the example files under `app/`.

## Validation

- Verified both example files exist at the corrected paths.
- Ran `git diff --check`.
