### PR TITLE
Retry screensaver loading after filtered batches

### DIFF
--- a/app/src/main/java/nl/giejay/android/tv/immich/album/AlbumDetailsFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/album/AlbumDetailsFragment.kt
@@ -37,7 +37,7 @@ class AlbumDetailsFragment : GenericAssetFragment() {
             order = if (currentSort == PhotosOrder.NEWEST_OLDEST) "desc" else "asc",
             contentType = currentFilter,
             albumIds = listOf(albumId)
-        ).map { it.map { a -> a.copy(albumName = albumName) } }
+        ).map { it.assets.map { a -> a.copy(albumName = albumName) } }
     }
 
     override fun onItemSelected(card: Card, indexOf: Int) {

--- a/app/src/main/java/nl/giejay/android/tv/immich/api/ApiClient.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/api/ApiClient.kt
@@ -7,6 +7,7 @@ import arrow.core.flatMap
 import arrow.core.getOrElse
 import nl.giejay.android.tv.immich.api.model.Album
 import nl.giejay.android.tv.immich.api.model.Asset
+import nl.giejay.android.tv.immich.api.model.AssetResponse
 import nl.giejay.android.tv.immich.api.model.Folder
 import nl.giejay.android.tv.immich.api.model.Memory
 import nl.giejay.android.tv.immich.api.model.Person
@@ -73,6 +74,12 @@ internal fun resolveWithPartners(showPartnerPhotosInTimeline: Boolean): Boolean?
     return if (showPartnerPhotosInTimeline) true else null
 }
 
+internal fun SearchResponse.toAssetResponse(): AssetResponse =
+    AssetResponse(assets.items, assets.nextPage != null)
+
+internal fun List<Asset>.toRandomAssetResponse(): AssetResponse =
+    AssetResponse(this, true)
+
 class ApiClient(private val config: ApiClientConfig) {
     companion object ApiClient {
         private var apiClient: nl.giejay.android.tv.immich.api.ApiClient? = null
@@ -112,7 +119,7 @@ class ApiClient(private val config: ApiClientConfig) {
 
     suspend fun listAssetsFromAlbum(albumIds: List<String>,
                                     contentType: ContentType = ContentType.ALL,
-                                    pageCount: Int = 100): Either<String, List<Asset>> {
+                                    pageCount: Int = 100): Either<String, AssetResponse> {
         val results = albumIds.pmap { albumId ->
             val album = executeAPICall(200) { service.getAlbum(albumId) }
                 .getOrElse { return@pmap Either.Left(it) }
@@ -143,19 +150,19 @@ class ApiClient(private val config: ApiClientConfig) {
             val assets = res.getOrElse { return Either.Left(it) }
             allAssets.addAll(assets)
         }
-        return Either.Right(allAssets.filter(excludeByTag()))
+        return Either.Right(AssetResponse(allAssets.filter(excludeByTag()), false))
     }
 
-    suspend fun recentAssets(page: Int, pageCount: Int, contentType: ContentType): Either<String, List<Asset>> {
+    suspend fun recentAssets(page: Int, pageCount: Int, contentType: ContentType): Either<String, AssetResponse> {
         val now = LocalDateTime.now()
         return listAssets(page, pageCount, true, "desc",
             contentType = contentType, fromDate = now.minusMonths(PreferenceManager.get(RECENT_ASSETS_MONTHS_BACK).toLong()), endDate = now)
-            .map { it.shuffled() }
+            .map { it.copy(assets = it.assets.shuffled()) }
     }
 
-    suspend fun similarAssets(page: Int, pageCount: Int, contentType: ContentType): Either<String, List<Asset>> {
+    suspend fun similarAssets(page: Int, pageCount: Int, contentType: ContentType): Either<String, AssetResponse> {
         val now = LocalDateTime.now()
-        val map: List<Either<String, List<Asset>>> = (0 until PreferenceManager.get(SIMILAR_ASSETS_YEARS_BACK)).toList().map {
+        val map: List<Either<String, AssetResponse>> = (0 until PreferenceManager.get(SIMILAR_ASSETS_YEARS_BACK)).toList().map {
             listAssets(page,
                 pageCount,
                 true,
@@ -167,7 +174,11 @@ class ApiClient(private val config: ApiClientConfig) {
         if (map.all { it.isLeft() }) {
             return map.first()
         }
-        return Either.Right(map.flatMap { it.getOrElse { emptyList() } }.shuffled())
+        val responses = map.mapNotNull { it.getOrNull() }
+        return Either.Right(AssetResponse(
+            responses.flatMap { it.assets }.shuffled(),
+            responses.any { it.canLoadMore }
+        ))
     }
 
     suspend fun listAssets(page: Int,
@@ -178,7 +189,7 @@ class ApiClient(private val config: ApiClientConfig) {
                            fromDate: LocalDateTime? = null,
                            endDate: LocalDateTime? = null,
                            contentType: ContentType,
-                           albumIds: List<String> = emptyList()): Either<String, List<Asset>> {
+                           albumIds: List<String> = emptyList()): Either<String, AssetResponse> {
         val searchRequest = buildListAssetsSearchRequest(
             page = page,
             pageCount = pageCount,
@@ -195,8 +206,9 @@ class ApiClient(private val config: ApiClientConfig) {
             // stricter request validation rejects unknown properties with a 400, so they must be
             // stripped here rather than sent as on the metadata-search path below.
             executeAPICall(200) { service.randomAssets(searchRequest.copy(page = null, order = null)) }
+                .map { it.toRandomAssetResponse() }
         } else {
-            search(searchRequest).map { it.assets.items }
+            search(searchRequest).map { it.toAssetResponse() }
         }
         return assetsResult
     }

--- a/app/src/main/java/nl/giejay/android/tv/immich/api/model/AssetResponse.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/api/model/AssetResponse.kt
@@ -1,0 +1,10 @@
+package nl.giejay.android.tv.immich.api.model
+
+/**
+ * Assets returned by one request and whether the source can be queried again.
+ * Random sources can load again even though they do not have literal pages.
+ */
+data class AssetResponse(
+    val assets: List<Asset>,
+    val canLoadMore: Boolean
+)

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/AllAssetFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/AllAssetFragment.kt
@@ -18,7 +18,7 @@ class AllAssetFragment : GenericAssetFragment() {
             pageCount,
             false,
             if (currentSort == PhotosOrder.NEWEST_OLDEST) "desc" else "asc",
-            contentType = currentFilter)
+            contentType = currentFilter).map { it.assets }
     }
 
     override fun showMediaCount(): Boolean {

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
@@ -29,6 +29,7 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
 import nl.giejay.android.tv.immich.shared.util.toCard
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
 import nl.giejay.mediaslider.config.MediaSliderConfiguration
+import nl.giejay.mediaslider.util.LoadMoreResult
 import nl.giejay.mediaslider.viewmodel.MediaSliderViewModel
 
 data class Item(val item: Any) {
@@ -96,7 +97,7 @@ class FolderFragment : VerticalCardGridFragment<Item>() {
                 PreferenceManager.get(SLIDER_ONLY_USE_THUMBNAILS),
                 isVideoSoundEnable = true,
                 sliderItems,
-                { listOf() },
+                { LoadMoreResult(emptyList(), false) },
                 { item -> manualUpdatePosition(this.assets.indexOfFirst { item.ids().contains(it.id) }) },
                 animationSpeedMillis = PreferenceManager.get(SLIDER_ANIMATION_SPEED),
                 maxCutOffHeight = PreferenceManager.get(SLIDER_MAX_CUT_OFF_HEIGHT),

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import nl.giejay.android.tv.immich.album.AlbumDetailsFragmentDirections
 import nl.giejay.android.tv.immich.api.model.Asset
+import nl.giejay.android.tv.immich.api.model.AssetResponse
 import nl.giejay.android.tv.immich.api.util.ApiUtil
 import nl.giejay.android.tv.immich.card.Card
 import nl.giejay.android.tv.immich.home.HomeFragmentDirections
@@ -42,6 +43,7 @@ import nl.giejay.android.tv.immich.shared.util.toCard
 import nl.giejay.android.tv.immich.shared.util.toSliderItems
 import nl.giejay.mediaslider.config.MediaSliderConfiguration
 import nl.giejay.mediaslider.util.LoadMore
+import nl.giejay.mediaslider.util.LoadMoreResult
 import nl.giejay.mediaslider.viewmodel.MediaSliderViewModel
 
 abstract class GenericAssetFragment : VerticalCardGridFragment<Asset>() {
@@ -84,7 +86,8 @@ abstract class GenericAssetFragment : VerticalCardGridFragment<Asset>() {
             if (excludedAlbums.isNotEmpty()) {
                 excludedAssetIds = excludedAlbums.toList().pmap {
                     apiClient.listAssetsFromAlbum(listOf(it), pageCount = 1000)
-                        .getOrElse { emptyList() }
+                        .getOrElse { AssetResponse(emptyList(), false) }
+                        .assets
                         .map { it -> it.id }
                 }.flatten().toSet()
             }
@@ -137,7 +140,10 @@ abstract class GenericAssetFragment : VerticalCardGridFragment<Asset>() {
                 val moreAssets = loadMoreAssets()
                 // also load the data in the overview
                 setDataOnMain(moreAssets)
-                moreAssets.toSliderItems(true, PreferenceManager.get(SLIDER_MERGE_PORTRAIT_PHOTOS))
+                LoadMoreResult(
+                    moreAssets.toSliderItems(true, PreferenceManager.get(SLIDER_MERGE_PORTRAIT_PHOTOS)),
+                    moreAssets.isNotEmpty() && !allPagesLoaded
+                )
             }
 
             withContext(Dispatchers.Main) {

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/RandomAssetsFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/RandomAssetsFragment.kt
@@ -14,6 +14,6 @@ class RandomAssetsFragment : GenericAssetFragment() {
         return apiClient.listAssets(page,
             pageCount,
             random = true,
-            contentType = currentFilter)
+            contentType = currentFilter).map { it.assets }
     }
 }

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/RecentAssetsFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/RecentAssetsFragment.kt
@@ -11,6 +11,6 @@ class RecentAssetsFragment : GenericAssetFragment() {
         page: Int,
         pageCount: Int
     ): Either<String, List<Asset>> {
-        return apiClient.recentAssets(page, pageCount, currentFilter)
+        return apiClient.recentAssets(page, pageCount, currentFilter).map { it.assets }
     }
 }

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/SimilarTimeAssetsFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/SimilarTimeAssetsFragment.kt
@@ -11,6 +11,6 @@ class SimilarTimeAssetsFragment : GenericAssetFragment() {
         page: Int,
         pageCount: Int
     ): Either<String, List<Asset>> {
-        return apiClient.similarAssets(page, pageCount, currentFilter)
+        return apiClient.similarAssets(page, pageCount, currentFilter).map { it.assets }
     }
 }

--- a/app/src/main/java/nl/giejay/android/tv/immich/people/PersonAssetsFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/people/PersonAssetsFragment.kt
@@ -27,7 +27,7 @@ class PersonAssetsFragment : GenericAssetFragment() {
             random = true,
             order = "desc",
             contentType = currentFilter,
-            personIds = listOf(UUID.fromString(personId))).map { it.shuffled() }
+            personIds = listOf(UUID.fromString(personId))).map { it.assets.shuffled() }
     }
 
     override fun showMediaCount(): Boolean {

--- a/app/src/main/java/nl/giejay/android/tv/immich/screensaver/FilteredAssetLoader.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/screensaver/FilteredAssetLoader.kt
@@ -1,0 +1,87 @@
+package nl.giejay.android.tv.immich.screensaver
+
+import arrow.core.Either
+import kotlinx.coroutines.delay
+import nl.giejay.android.tv.immich.api.model.Asset
+import nl.giejay.android.tv.immich.api.model.AssetResponse
+
+internal class EmptyFilteredBatchBackoff(
+    private val retryDelaysMillis: List<Long> = DEFAULT_RETRY_DELAYS_MILLIS
+) {
+    init {
+        require(retryDelaysMillis.isNotEmpty())
+        require(retryDelaysMillis.all { it >= 0 })
+    }
+
+    private var attempt = 0
+
+    fun delayBeforeNextRequestMillis(): Long = retryDelaysMillis[attempt.coerceAtMost(retryDelaysMillis.lastIndex)]
+
+    fun recordEmptyBatch() {
+        if (attempt < retryDelaysMillis.lastIndex) {
+            attempt += 1
+        }
+    }
+
+    fun reset() {
+        attempt = 0
+    }
+
+    companion object {
+        private val DEFAULT_RETRY_DELAYS_MILLIS = listOf(
+            0L,
+            1_000L,
+            2_000L,
+            4_000L,
+            8_000L,
+            16_000L,
+            32_000L,
+            60_000L,
+            120_000L,
+            240_000L,
+            480_000L,
+            960_000L,
+            1_920_000L,
+            3_600_000L
+        )
+    }
+}
+
+/**
+ * Retries repeatable asset sources when every returned asset is excluded locally.
+ * Errors and genuinely exhausted sources are returned without retrying.
+ */
+internal class FilteredAssetLoader(
+    private val filterAssets: (List<Asset>) -> List<Asset>,
+    private val backoff: EmptyFilteredBatchBackoff = EmptyFilteredBatchBackoff(),
+    private val wait: suspend (Long) -> Unit = { delay(it) }
+) {
+    fun reset() {
+        backoff.reset()
+    }
+
+    suspend fun load(fetch: suspend () -> Either<String, AssetResponse>): Either<String, AssetResponse> {
+        while (true) {
+            val retryDelayMillis = backoff.delayBeforeNextRequestMillis()
+            if (retryDelayMillis > 0) {
+                wait(retryDelayMillis)
+            }
+
+            when (val result = fetch()) {
+                is Either.Left -> {
+                    backoff.reset()
+                    return result
+                }
+                is Either.Right -> {
+                    val response = result.value
+                    val filteredAssets = filterAssets(response.assets)
+                    if (filteredAssets.isNotEmpty() || !response.canLoadMore) {
+                        backoff.reset()
+                        return Either.Right(response.copy(assets = filteredAssets))
+                    }
+                    backoff.recordEmptyBatch()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
@@ -6,7 +6,6 @@ import android.view.KeyEvent
 import android.widget.Toast
 import androidx.media3.datasource.DefaultHttpDataSource
 import arrow.core.Either
-import arrow.core.flatten
 import arrow.core.getOrElse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -18,6 +17,7 @@ import nl.giejay.android.tv.immich.R
 import nl.giejay.android.tv.immich.api.ApiClient
 import nl.giejay.android.tv.immich.api.ApiClientConfig
 import nl.giejay.android.tv.immich.api.model.Asset
+import nl.giejay.android.tv.immich.api.model.AssetResponse
 import nl.giejay.android.tv.immich.shared.prefs.API_KEY
 import nl.giejay.android.tv.immich.shared.prefs.ContentType
 import nl.giejay.android.tv.immich.shared.prefs.DEBUG_MODE
@@ -46,6 +46,7 @@ import nl.giejay.android.tv.immich.slider.FavoriteButtonControllerPlugin
 import nl.giejay.android.tv.immich.slider.FavoriteService
 import nl.giejay.mediaslider.config.MediaSliderConfiguration
 import nl.giejay.mediaslider.util.LoadMore
+import nl.giejay.mediaslider.util.LoadMoreResult
 import nl.giejay.mediaslider.util.MediaSliderListener
 import nl.giejay.mediaslider.view.MediaSliderView
 import timber.log.Timber
@@ -55,18 +56,25 @@ internal fun <T> Either<String, T>.getOrElseLogged(logContext: String, default: 
     this.onLeft { error -> Timber.w("Failed to load assets for %s: %s", logContext, error) }
         .getOrElse { default }
 
+internal fun filterExcludedAssets(assets: List<Asset>, excludedAssetIds: Set<String>): List<Asset> =
+    assets.filter { asset -> asset.tags?.none { it.name == "exclude_immich_tv" } ?: true }
+        .filterNot { excludedAssetIds.contains(it.id) }
+
 class ScreenSaverService : DreamService(), MediaSliderListener {
     private var ioScope = CoroutineScope(Job() + Dispatchers.IO)
     private lateinit var apiClient: ApiClient
     private val favoriteService = FavoriteService()
     private var mediaSliderView: MediaSliderView? = null
     private var currentPage = 0
-    private var doneLoading: Boolean = false
     private var excludedAssetIds: Set<String> = emptySet()
+    private val filteredAssetLoader = FilteredAssetLoader(
+        filterAssets = { filterExcludedAssets(it, excludedAssetIds) }
+    )
 
     @SuppressLint("UnsafeOptInUsageError")
     override fun onDreamingStarted() {
         ioScope = CoroutineScope(Job() + Dispatchers.IO)
+        filteredAssetLoader.reset()
         Timber.i("Starting screensaver")
         if (!PreferenceManager.isLoggedId()) {
             showErrorMessage(getString(R.string.screensaver_not_possible))
@@ -92,7 +100,8 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
             val excludedAlbums = PreferenceManager.get(EXCLUDE_ASSETS_IN_ALBUM)
             if (excludedAlbums.isNotEmpty()) {
                 excludedAssetIds = apiClient.listAssetsFromAlbum(excludedAlbums.toList(), pageCount = 5000)
-                    .getOrElse { emptyList() }
+                    .getOrElse { AssetResponse(emptyList(), false) }
+                    .assets
                     .map { it.id }
                     .toSet()
             }
@@ -101,23 +110,11 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
                 loadImagesFromAlbums(PreferenceManager.get(SCREENSAVER_ALBUMS).toList())
             } else {
                 val screenSaverType = PreferenceManager.get(SCREENSAVER_TYPE)
-                loadRandomImages(screenSaverType).invoke().map {
-                    setInitialAssets(it, suspend {
-                        if (doneLoading) {
-                            emptyList()
-                        } else {
-                            currentPage += 1
-                            val contentType = if (PreferenceManager.get(SCREENSAVER_INCLUDE_VIDEOS)) ContentType.ALL else ContentType.IMAGE
-                            val result = when (screenSaverType) {
-                                ScreenSaverType.RECENT -> apiClient.recentAssets(currentPage, PAGE_COUNT, contentType = contentType)
-                                ScreenSaverType.SIMILAR_TIME_PERIOD -> apiClient.similarAssets(currentPage, PAGE_COUNT, contentType = contentType)
-                                else -> apiClient.listAssets(currentPage, PAGE_COUNT, true, contentType = contentType)
-                            }
-                            val rawAssets = result.getOrElseLogged("screensaver random/recent/similar loadMore", emptyList())
-                            doneLoading = rawAssets.size < PAGE_COUNT
-                            filterAssets(rawAssets).toSliderItems(false, PreferenceManager.get(SLIDER_MERGE_PORTRAIT_PHOTOS))
-                        }
-                    })
+                filteredAssetLoader.load { loadNextAssets(screenSaverType) }.map { response ->
+                    setInitialAssets(
+                        response.assets,
+                        if (response.canLoadMore) createLoadMore { loadNextAssets(screenSaverType) } else null
+                    )
                 }
             }
         }
@@ -129,40 +126,58 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
         super.onDreamingStopped()
     }
 
-    private fun loadRandomImages(screenSaverType: ScreenSaverType): suspend () -> Either<String, List<Asset>> {
+    private suspend fun loadNextAssets(screenSaverType: ScreenSaverType): Either<String, AssetResponse> {
         val contentType = if (PreferenceManager.get(SCREENSAVER_INCLUDE_VIDEOS)) ContentType.ALL else ContentType.IMAGE
-        return suspend {
-            val result = when (screenSaverType) {
-                ScreenSaverType.RECENT -> apiClient.recentAssets(currentPage, PAGE_COUNT, contentType = contentType)
-                ScreenSaverType.SIMILAR_TIME_PERIOD -> apiClient.similarAssets(currentPage, PAGE_COUNT, contentType = contentType)
-                else -> apiClient.listAssets(currentPage, PAGE_COUNT, true, contentType = contentType)
-            }
-            result.map { filterAssets(it) }
+        val page = currentPage
+        currentPage += 1
+        return when (screenSaverType) {
+            ScreenSaverType.RECENT -> apiClient.recentAssets(page, PAGE_COUNT, contentType = contentType)
+            ScreenSaverType.SIMILAR_TIME_PERIOD -> apiClient.similarAssets(page, PAGE_COUNT, contentType = contentType)
+            else -> apiClient.listAssets(page, PAGE_COUNT, true, contentType = contentType)
         }
+    }
+
+    private fun createLoadMore(fetch: suspend () -> Either<String, AssetResponse>): LoadMore = suspend {
+        filteredAssetLoader.load(fetch).fold(
+            { error ->
+                Timber.w("Failed to load more screensaver assets: %s", error)
+                LoadMoreResult(emptyList(), false)
+            },
+            { response ->
+                LoadMoreResult(
+                    response.assets.toSliderItems(false, PreferenceManager.get(SLIDER_MERGE_PORTRAIT_PHOTOS)),
+                    response.canLoadMore
+                )
+            }
+        )
     }
 
     private suspend fun loadImagesFromAlbums(albums: List<String>) {
         try {
             if (albums.isNotEmpty()) {
-                // first load x random assets from each album. Then load all assets from all albums.
-                val initialAssets = loadNextAssetsFromAlbums(albums, random = true)
-                if(initialAssets.isEmpty()){
-                    // this is a fallback for an issue with the random endpoint where its not able to return shared albums yet
-                    // just retrieve all assets from the albums and show them in the screensaver
-                    Timber.w("No random assets found for albums $albums, falling back to loading all assets from albums")
-                    loadNextAssetsFromAlbums(albums, random = false).let {
-                        if(it.isEmpty()){
-                            showErrorMessageMainScope(getString(R.string.no_assets_for_screensaver))
-                            finish()
-                        } else {
-                            setInitialAssets(it, null)
-                        }
+                var loadRandomAssets = true
+                val initialResponse = filteredAssetLoader.load {
+                    if (loadRandomAssets) {
+                        loadRandomAssets = false
+                        loadNextAssetsFromAlbums(albums, random = true).fold(
+                            {
+                                Timber.w("Could not load random assets for albums $albums, falling back to all album assets")
+                                loadNextAssetsFromAlbums(albums, random = false)
+                            },
+                            { Either.Right(it) }
+                        )
+                    } else {
+                        Timber.w("Random album sample was empty after exclusions for albums $albums, checking their complete asset lists")
+                        loadNextAssetsFromAlbums(albums, random = false)
                     }
-                } else {
-                    setInitialAssets(initialAssets, suspend {
-                        loadNextAssetsFromAlbums(albums, random = false).toSliderItems(false, PreferenceManager.get(SLIDER_MERGE_PORTRAIT_PHOTOS))
-                    })
-                }
+                }.getOrElse { throw IllegalStateException(it) }
+
+                setInitialAssets(
+                    initialResponse.assets,
+                    if (initialResponse.canLoadMore) {
+                        createLoadMore { loadNextAssetsFromAlbums(albums, random = false) }
+                    } else null
+                )
             } else {
                 showErrorMessageMainScope(getString(R.string.set_albums_screensaver_error))
                 finish()
@@ -174,33 +189,27 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
         }
     }
 
-    private suspend fun loadNextAssetsFromAlbums(albums: List<String>, random: Boolean = false): List<Asset> {
+    private suspend fun loadNextAssetsFromAlbums(albums: List<String>, random: Boolean = false): Either<String, AssetResponse> {
         val contentType = if (PreferenceManager.get(SCREENSAVER_INCLUDE_VIDEOS)) ContentType.ALL else ContentType.IMAGE
-        val assets = if (random) {
+        if (random) {
             val pageCount = (50 / albums.size).coerceAtLeast(1)
-            albums.pmap { albumId ->
+            val responses = albums.pmap { albumId ->
                 apiClient.listAssets(
                     page = 1,
                     pageCount = pageCount,
                     random = true,
                     contentType = contentType,
                     albumIds = listOf(albumId)
-                ).getOrElse { emptyList() }
-            }.flatten()
+                )
+            }
+            responses.firstOrNull { it.isLeft() }?.let { return it }
+            return Either.Right(AssetResponse(
+                responses.flatMap { it.getOrElse { AssetResponse(emptyList(), true) }.assets }.shuffled(),
+                true
+            ))
         } else {
-            apiClient.listAssetsFromAlbum(albums, contentType, pageCount = 1000).getOrElse { emptyList() }
+            return apiClient.listAssetsFromAlbum(albums, contentType, pageCount = 1000)
         }
-
-        return filterAssets(assets).shuffled()
-    }
-
-    private fun filterAssets(assets: List<Asset>): List<Asset> {
-        return assets.filter(excludeByTag())
-            .filterNot { excludedAssetIds.contains(it.id) }
-    }
-
-    private fun excludeByTag() = { asset: Asset ->
-        asset.tags?.none { t -> t.name == "exclude_immich_tv" } ?: true
     }
 
     private suspend fun showErrorMessageMainScope(errorMessage: String) {
@@ -218,11 +227,7 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
     }
 
     private suspend fun setInitialAssets(assets: List<Asset>, loadMore: LoadMore?) = withContext(Dispatchers.Main) {
-        if (assets.isEmpty()) {
-            Toast.makeText(this@ScreenSaverService,
-                getString(R.string.no_assets_for_screensaver),
-                Toast.LENGTH_LONG).show()
-        } else {
+        if (assets.isNotEmpty()) {
             mediaSliderView?.loadMediaSliderView(
                 MediaSliderConfiguration(
                     0,

--- a/app/src/main/java/nl/giejay/android/tv/immich/timeline/TimelineFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/timeline/TimelineFragment.kt
@@ -59,6 +59,7 @@ import nl.giejay.android.tv.immich.shared.util.toSliderItems
 import nl.giejay.mediaslider.config.MediaSliderConfiguration
 import nl.giejay.mediaslider.model.MetaDataType
 import nl.giejay.mediaslider.util.LoadMore
+import nl.giejay.mediaslider.util.LoadMoreResult
 import nl.giejay.mediaslider.viewmodel.MediaSliderViewModel
 import java.time.LocalDate
 import kotlin.math.roundToInt
@@ -1019,14 +1020,15 @@ class TimelineFragment : BrandedSupportFragment(), BrowseSupportFragment.MainFra
             }
 
             val loadMore: LoadMore = suspend loadMore@{
-                val afterKey = lastBucketKey ?: return@loadMore emptyList()
-                val next = viewModel.nextBucketAfter(afterKey) ?: return@loadMore emptyList()
+                val afterKey = lastBucketKey ?: return@loadMore LoadMoreResult(emptyList(), false)
+                val next = viewModel.nextBucketAfter(afterKey) ?: return@loadMore LoadMoreResult(emptyList(), false)
                 val knownIds = initialAssets.map { it.id }.toSet()
                 viewModel.loadBucket(next.timeBucket)
                 lastBucketKey = next.timeBucket
-                viewModel.bucketAssets.value[next.timeBucket].orEmpty()
+                val items = viewModel.bucketAssets.value[next.timeBucket].orEmpty()
                     .filter { it.id !in knownIds }
                     .pmap { it.toSliderItemViewHolder() }
+                LoadMoreResult(items, items.isNotEmpty() && viewModel.nextBucketAfter(next.timeBucket) != null)
             }
 
             withContext(Dispatchers.Main) {

--- a/app/src/test/java/nl/giejay/android/tv/immich/api/AssetResponseTest.kt
+++ b/app/src/test/java/nl/giejay/android/tv/immich/api/AssetResponseTest.kt
@@ -1,0 +1,51 @@
+package nl.giejay.android.tv.immich.api
+
+import com.google.common.truth.Truth.assertThat
+import nl.giejay.android.tv.immich.api.model.Asset
+import nl.giejay.android.tv.immich.api.model.SearchAlbumResponseDto
+import nl.giejay.android.tv.immich.api.model.SearchAssetResponseDto
+import nl.giejay.android.tv.immich.api.model.SearchResponse
+import org.junit.Test
+
+class AssetResponseTest {
+    @Test
+    fun `search response with a next page maps to can load more`() {
+        val response = searchResponse(nextPage = "2").toAssetResponse()
+
+        assertThat(response.assets.map { it.id }).containsExactly("asset-1")
+        assertThat(response.canLoadMore).isTrue()
+    }
+
+    @Test
+    fun `search response without a next page maps to cannot load more`() {
+        assertThat(searchResponse(nextPage = null).toAssetResponse().canLoadMore).isFalse()
+    }
+
+    @Test
+    fun `random asset list maps to another sample being available`() {
+        assertThat(emptyList<Asset>().toRandomAssetResponse().canLoadMore).isTrue()
+    }
+
+    private fun searchResponse(nextPage: String?) = SearchResponse(
+        albums = SearchAlbumResponseDto(total = 0, count = 0, items = emptyList()),
+        assets = SearchAssetResponseDto(
+            total = 1,
+            count = 1,
+            items = listOf(asset("asset-1")),
+            nextPage = nextPage
+        )
+    )
+
+    private fun asset(id: String) = Asset(
+        id = id,
+        type = "IMAGE",
+        deviceAssetId = null,
+        exifInfo = null,
+        fileModifiedAt = null,
+        albumName = null,
+        people = null,
+        tags = null,
+        originalPath = null,
+        originalFileName = null
+    )
+}

--- a/app/src/test/java/nl/giejay/android/tv/immich/screensaver/FilteredAssetLoaderTest.kt
+++ b/app/src/test/java/nl/giejay/android/tv/immich/screensaver/FilteredAssetLoaderTest.kt
@@ -1,0 +1,149 @@
+package nl.giejay.android.tv.immich.screensaver
+
+import arrow.core.Either
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import nl.giejay.android.tv.immich.api.model.Asset
+import nl.giejay.android.tv.immich.api.model.AssetResponse
+import nl.giejay.android.tv.immich.api.model.Tag
+import org.junit.Test
+import java.util.Date
+
+class FilteredAssetLoaderTest {
+    @Test
+    fun `backoff returns the configured delay sequence capped at one hour`() {
+        val backoff = EmptyFilteredBatchBackoff()
+        val delays = buildList {
+            repeat(15) {
+                add(backoff.delayBeforeNextRequestMillis())
+                backoff.recordEmptyBatch()
+            }
+        }
+
+        assertThat(delays).containsExactly(
+            0L,
+            1_000L,
+            2_000L,
+            4_000L,
+            8_000L,
+            16_000L,
+            32_000L,
+            60_000L,
+            120_000L,
+            240_000L,
+            480_000L,
+            960_000L,
+            1_920_000L,
+            3_600_000L,
+            3_600_000L
+        ).inOrder()
+    }
+
+    @Test
+    fun `load retries empty filtered batches until filtering returns an asset`() = runTest {
+        val waits = mutableListOf<Long>()
+        val responses = ArrayDeque(listOf(
+            AssetResponse(listOf(asset("excluded-1")), true),
+            AssetResponse(listOf(asset("excluded-2")), true),
+            AssetResponse(listOf(asset("included")), true)
+        ))
+        val loader = FilteredAssetLoader(
+            filterAssets = { assets -> assets.filter { it.id == "included" } },
+            wait = { waits.add(it) }
+        )
+
+        val result = loader.load { Either.Right(responses.removeFirst()) }
+
+        assertThat(result.getOrNull()!!.assets.map { it.id }).containsExactly("included")
+        assertThat(waits).containsExactly(1_000L, 2_000L).inOrder()
+    }
+
+    @Test
+    fun `load returns an empty result when its source cannot load more`() = runTest {
+        var fetchCount = 0
+        val waits = mutableListOf<Long>()
+        val loader = FilteredAssetLoader(
+            filterAssets = { emptyList() },
+            wait = { waits.add(it) }
+        )
+
+        val result = loader.load {
+            fetchCount += 1
+            Either.Right(AssetResponse(listOf(asset("excluded")), false))
+        }
+
+        assertThat(result.getOrNull()!!.assets).isEmpty()
+        assertThat(result.getOrNull()!!.canLoadMore).isFalse()
+        assertThat(fetchCount).isEqualTo(1)
+        assertThat(waits).isEmpty()
+    }
+
+    @Test
+    fun `non-empty filtered result resets the delay before the next load`() = runTest {
+        val waits = mutableListOf<Long>()
+        val loader = FilteredAssetLoader(
+            filterAssets = { assets -> assets.filter { it.id == "included" } },
+            wait = { waits.add(it) }
+        )
+
+        suspend fun loadAfterOneExcludedBatch() {
+            var firstRequest = true
+            loader.load {
+                if (firstRequest) {
+                    firstRequest = false
+                    Either.Right(AssetResponse(listOf(asset("excluded")), true))
+                } else {
+                    Either.Right(AssetResponse(listOf(asset("included")), true))
+                }
+            }
+        }
+
+        loadAfterOneExcludedBatch()
+        loadAfterOneExcludedBatch()
+
+        assertThat(waits).containsExactly(1_000L, 1_000L).inOrder()
+    }
+
+    @Test
+    fun `load returns an API failure without waiting`() = runTest {
+        val waits = mutableListOf<Long>()
+        val loader = FilteredAssetLoader(
+            filterAssets = { it },
+            wait = { waits.add(it) }
+        )
+
+        val result = loader.load { Either.Left("request failed") }
+
+        assertThat(result.leftOrNull()).isEqualTo("request failed")
+        assertThat(waits).isEmpty()
+    }
+
+    @Test
+    fun `filter removes assets with the exclusion tag or an excluded album ID`() {
+        val included = asset("included")
+        val tagged = asset("tagged").copy(
+            tags = listOf(Tag(null, Date(0), "exclude_immich_tv", ""))
+        )
+        val inExcludedAlbum = asset("in-excluded-album")
+
+        val result = filterExcludedAssets(
+            listOf(tagged, inExcludedAlbum, included),
+            setOf(inExcludedAlbum.id)
+        )
+
+        assertThat(result).containsExactly(included)
+    }
+
+    private fun asset(id: String) = Asset(
+        id = id,
+        type = "IMAGE",
+        deviceAssetId = null,
+        exifInfo = null,
+        fileModifiedAt = null,
+        albumName = null,
+        people = null,
+        tags = null,
+        originalPath = null,
+        originalFileName = null
+    )
+}

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/util/LoadMore.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/util/LoadMore.kt
@@ -2,4 +2,10 @@ package nl.giejay.mediaslider.util
 
 import nl.giejay.mediaslider.model.SliderItemViewHolder
 
-typealias LoadMore = suspend () -> List<SliderItemViewHolder>
+/** Keeps an empty load result distinct from reaching the end of the source. */
+data class LoadMoreResult(
+    val items: List<SliderItemViewHolder>,
+    val canLoadMore: Boolean
+)
+
+typealias LoadMore = suspend () -> LoadMoreResult

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/view/MediaSliderView.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/view/MediaSliderView.kt
@@ -39,6 +39,7 @@ import nl.giejay.mediaslider.plugin.MetadataViewPlugin
 import nl.giejay.mediaslider.plugin.SliderViewPlugin
 import nl.giejay.mediaslider.plugin.SliderViewPluginContext
 import nl.giejay.mediaslider.util.FixedSpeedScroller
+import nl.giejay.mediaslider.util.LoadMoreResult
 import timber.log.Timber
 import java.lang.reflect.Field
 
@@ -194,9 +195,13 @@ open class MediaSliderView(context: Context) : ConstraintLayout(context) {
                 if (config.loadMore != null && mPager.currentItem > config.items.size - 40 && !loading) {
                     loading = true
                     ioScope.launch {
-                        val nextItems = config.loadMore!!.invoke()
-                        addItemsMain(nextItems)
-                        loading = nextItems.isEmpty()
+                        val loadMore = config.loadMore ?: return@launch
+                        val result: LoadMoreResult = loadMore()
+                        addItemsMain(result.items)
+                        if (!result.canLoadMore) {
+                            config.loadMore = null
+                        }
+                        loading = false
                     }
                 }
                 controller.stopPlayer()


### PR DESCRIPTION
## Summary

- return asset batches with explicit `canLoadMore` state from `ApiClient`
- let the media slider distinguish an empty batch from an exhausted source
- retry screensaver batches that become empty after configured exclusions
- cover continuation mapping, exclusion filtering, retry delays, reset behavior, exhaustion, and API failures with unit tests

## Behaviour

Paginated sources derive `canLoadMore` from the server's next-page metadata. Random sources remain repeatable because another sample can be requested, while fully collected album assets are marked exhausted.

When a repeatable screensaver source returns a batch that is empty after the existing tag and excluded-album filters, the next request is delayed using `1s, 2s, 4s, ...` up to one hour. Further attempts remain capped at one per hour, avoiding a tight request loop when every asset is excluded. A non-empty filtered result resets the delay. API failures are returned immediately and exhausted sources are not retried.

If an initial load remains empty while retrying, the screensaver keeps its blank background. Assets already loaded into the slider continue their normal circulation while a later load is waiting.

## Verification

- `./gradlew :app:testDebugUnitTest assembleDebug test`
- `git diff --check`

Fixes #245
