### PR TITLE
feat(screensaver): in-app screensaver preview

### DIFF
--- a/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverAssetLoader.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverAssetLoader.kt
@@ -1,0 +1,274 @@
+package nl.giejay.android.tv.immich.screensaver
+
+import androidx.annotation.StringRes
+import arrow.core.Either
+import arrow.core.getOrElse
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import nl.giejay.android.tv.immich.R
+import nl.giejay.android.tv.immich.api.ApiClient
+import nl.giejay.android.tv.immich.api.ApiClientConfig
+import nl.giejay.android.tv.immich.api.model.Asset
+import nl.giejay.android.tv.immich.api.model.AssetResponse
+import nl.giejay.android.tv.immich.shared.prefs.API_KEY
+import nl.giejay.android.tv.immich.shared.prefs.ContentType
+import nl.giejay.android.tv.immich.shared.prefs.DEBUG_MODE
+import nl.giejay.android.tv.immich.shared.prefs.DISABLE_SSL_VERIFICATION
+import nl.giejay.android.tv.immich.shared.prefs.EXCLUDE_ASSETS_IN_ALBUM
+import nl.giejay.android.tv.immich.shared.prefs.MetaDataScreen
+import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
+import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ALBUMS
+import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ANIMATE_ASSET_SLIDE
+import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_INCLUDE_VIDEOS
+import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_INTERVAL
+import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_PLAY_SOUND
+import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_TYPE
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ANIMATION_SPEED
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_DPAD_SEEK_IN_VIDEO
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_FORCE_ORIGINAL_VIDEO
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_GLIDE_TRANSFORMATION
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_PAN_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
+import nl.giejay.android.tv.immich.shared.util.Utils.pmap
+import nl.giejay.android.tv.immich.shared.util.toSliderItems
+import nl.giejay.android.tv.immich.slider.FavoriteService
+import nl.giejay.mediaslider.config.MediaSliderConfiguration
+import nl.giejay.mediaslider.util.LoadMore
+import nl.giejay.mediaslider.util.LoadMoreResult
+import timber.log.Timber
+
+// internal so app/src/test can call it directly without instantiating ScreenSaverService
+internal fun <T> Either<String, T>.getOrElseLogged(logContext: String, default: T): T =
+    this.onLeft { error -> Timber.w("Failed to load assets for %s: %s", logContext, error) }
+        .getOrElse { default }
+
+internal fun filterExcludedAssets(assets: List<Asset>, excludedAssetIds: Set<String>): List<Asset> =
+    assets.filter { asset -> asset.tags?.none { it.name == "exclude_immich_tv" } ?: true }
+        .filterNot { excludedAssetIds.contains(it.id) }
+
+/** Single construction site of the screensaver's ApiClientConfig, shared by both hosts. */
+internal fun screenSaverApiClientConfig(): ApiClientConfig =
+    ApiClientConfig(
+        PreferenceManager.hostName,
+        PreferenceManager.get(API_KEY),
+        PreferenceManager.get(DISABLE_SSL_VERIFICATION),
+        PreferenceManager.get(DEBUG_MODE)
+    )
+
+/**
+ * THE single construction site of the screensaver MediaSliderConfiguration. Having exactly one
+ * literal is what guarantees the in-app preview and the real DreamService stay identical.
+ */
+internal fun buildScreenSaverConfiguration(
+    assets: List<Asset>,
+    loadMore: LoadMore?,
+    scope: CoroutineScope,
+    favoriteService: FavoriteService
+): MediaSliderConfiguration {
+    val enabledPlugins = PreferenceManager.createEnabledSliderPlugins(scope, favoriteService)
+    return MediaSliderConfiguration(
+        0,
+        PreferenceManager.get(SCREENSAVER_INTERVAL),
+        PreferenceManager.get(SLIDER_ONLY_USE_THUMBNAILS),
+        PreferenceManager.get(SCREENSAVER_PLAY_SOUND),
+        assets.toSliderItems(keepOrder = false, mergePortrait = PreferenceManager.get(SLIDER_MERGE_PORTRAIT_PHOTOS)),
+        loadMore,
+        animationSpeedMillis = PreferenceManager.get(SLIDER_ANIMATION_SPEED),
+        maxCutOffHeight = PreferenceManager.get(SLIDER_MAX_CUT_OFF_HEIGHT),
+        maxCutOffWidth = PreferenceManager.get(SLIDER_MAX_CUT_OFF_HEIGHT),
+        glideTransformation = PreferenceManager.get(SLIDER_GLIDE_TRANSFORMATION),
+        enableSlideAnimation = PreferenceManager.get(SCREENSAVER_ANIMATE_ASSET_SLIDE),
+        gradiantOverlay = true,
+        metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.SCREENSAVER),
+        zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS),
+        zoomEffectPercent = PreferenceManager.get(SLIDER_ZOOM_EFFECT),
+        panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
+        useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO),
+        dpadSeeksInVideo = PreferenceManager.get(SLIDER_DPAD_SEEK_IN_VIDEO),
+        controllerPlugins = enabledPlugins.controllerPlugins,
+        viewPlugins = enabledPlugins.viewPlugins,
+        keyEventPlugins = enabledPlugins.keyEventPlugins
+    )
+}
+
+/**
+ * Loads the assets for the Immich screensaver and builds its MediaSliderConfiguration.
+ *
+ * Context-agnostic on purpose: the host owns the view and all UI side effects, so the exact same
+ * loading pipeline backs both [ScreenSaverService] and the in-app [ScreenSaverPreviewFragment].
+ * Every [Host] callback is invoked on the main thread.
+ */
+class ScreenSaverAssetLoader(
+    private val scope: CoroutineScope,
+    private val apiClient: ApiClient,
+    private val host: Host,
+    private val favoriteService: FavoriteService = FavoriteService()
+) {
+    interface Host {
+        /** Host resolves [messageRes] against its own Context and shows a toast. */
+        fun showScreenSaverMessage(@StringRes messageRes: Int, longDuration: Boolean = false)
+
+        /** DreamService.finish() for the dream, NavController.popBackStack() for the preview. */
+        fun exitScreenSaver()
+
+        /** Host calls loadMediaSliderView(configuration) and starts the slideshow. */
+        fun onScreenSaverConfigurationReady(configuration: MediaSliderConfiguration)
+
+        /**
+         * True for the preview: leave the screen instead of sitting on black when there is
+         * nothing to show. The real dream keeps its existing stay-on-black behaviour.
+         */
+        val exitWhenNothingToShow: Boolean
+            get() = false
+    }
+
+    private var currentPage = 0
+    private var excludedAssetIds: Set<String> = emptySet()
+    private val filteredAssetLoader = FilteredAssetLoader(
+        filterAssets = { filterExcludedAssets(it, excludedAssetIds) }
+    )
+
+    fun start(): Job = scope.launch(Dispatchers.IO) {
+        val excludedAlbums = PreferenceManager.get(EXCLUDE_ASSETS_IN_ALBUM)
+        if (excludedAlbums.isNotEmpty()) {
+            excludedAssetIds = apiClient.listAssetsFromAlbum(excludedAlbums.toList(), pageCount = 5000)
+                .getOrElse { AssetResponse(emptyList(), false) }
+                .assets
+                .map { it.id }
+                .toSet()
+        }
+
+        if (ScreenSaverType.ALBUMS == PreferenceManager.get(SCREENSAVER_TYPE)) {
+            loadImagesFromAlbums(PreferenceManager.get(SCREENSAVER_ALBUMS).toList())
+        } else {
+            val screenSaverType = PreferenceManager.get(SCREENSAVER_TYPE)
+            filteredAssetLoader.load { loadNextAssets(screenSaverType) }.fold(
+                ifLeft = { error ->
+                    Timber.w("Failed to load assets for screensaver type %s: %s", screenSaverType, error)
+                    if (host.exitWhenNothingToShow) {
+                        failAndExit(R.string.could_not_load_assets)
+                    }
+                },
+                ifRight = { response ->
+                    setInitialAssets(
+                        response.assets,
+                        if (response.canLoadMore) createLoadMore { loadNextAssets(screenSaverType) } else null
+                    )
+                }
+            )
+        }
+    }
+
+    private suspend fun loadNextAssets(screenSaverType: ScreenSaverType): Either<String, AssetResponse> {
+        val contentType = if (PreferenceManager.get(SCREENSAVER_INCLUDE_VIDEOS)) ContentType.ALL else ContentType.IMAGE
+        val page = currentPage
+        currentPage += 1
+        return when (screenSaverType) {
+            ScreenSaverType.RECENT -> apiClient.recentAssets(page, PAGE_COUNT, contentType = contentType)
+            ScreenSaverType.SIMILAR_TIME_PERIOD -> apiClient.similarAssets(page, PAGE_COUNT, contentType = contentType)
+            else -> apiClient.listAssets(page, PAGE_COUNT, true, contentType = contentType)
+        }
+    }
+
+    private fun createLoadMore(fetch: suspend () -> Either<String, AssetResponse>): LoadMore = suspend {
+        filteredAssetLoader.load(fetch).fold(
+            { error ->
+                Timber.w("Failed to load more screensaver assets: %s", error)
+                LoadMoreResult(emptyList(), false)
+            },
+            { response ->
+                LoadMoreResult(
+                    response.assets.toSliderItems(false, PreferenceManager.get(SLIDER_MERGE_PORTRAIT_PHOTOS)),
+                    response.canLoadMore
+                )
+            }
+        )
+    }
+
+    private suspend fun loadImagesFromAlbums(albums: List<String>) {
+        try {
+            if (albums.isNotEmpty()) {
+                var loadRandomAssets = true
+                val initialResponse = filteredAssetLoader.load {
+                    if (loadRandomAssets) {
+                        loadRandomAssets = false
+                        loadNextAssetsFromAlbums(albums, random = true).fold(
+                            {
+                                Timber.w("Could not load random assets for albums $albums, falling back to all album assets")
+                                loadNextAssetsFromAlbums(albums, random = false)
+                            },
+                            { Either.Right(it) }
+                        )
+                    } else {
+                        Timber.w("Random album sample was empty after exclusions for albums $albums, checking their complete asset lists")
+                        loadNextAssetsFromAlbums(albums, random = false)
+                    }
+                }.getOrElse { throw IllegalStateException(it) }
+
+                setInitialAssets(
+                    initialResponse.assets,
+                    if (initialResponse.canLoadMore) {
+                        createLoadMore { loadNextAssetsFromAlbums(albums, random = false) }
+                    } else null
+                )
+            } else {
+                failAndExit(R.string.set_albums_screensaver_error)
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Could not fetch assets from Immich for Screensaver")
+            failAndExit(R.string.could_not_load_assets)
+        }
+    }
+
+    private suspend fun loadNextAssetsFromAlbums(albums: List<String>, random: Boolean = false): Either<String, AssetResponse> {
+        val contentType = if (PreferenceManager.get(SCREENSAVER_INCLUDE_VIDEOS)) ContentType.ALL else ContentType.IMAGE
+        if (random) {
+            val pageCount = (50 / albums.size).coerceAtLeast(1)
+            val responses = albums.pmap { albumId ->
+                apiClient.listAssets(
+                    page = 1,
+                    pageCount = pageCount,
+                    random = true,
+                    contentType = contentType,
+                    albumIds = listOf(albumId)
+                )
+            }
+            responses.firstOrNull { it.isLeft() }?.let { return it }
+            return Either.Right(AssetResponse(
+                responses.flatMap { it.getOrElse { AssetResponse(emptyList(), true) }.assets }.shuffled(),
+                true
+            ))
+        } else {
+            return apiClient.listAssetsFromAlbum(albums, contentType, pageCount = 1000)
+        }
+    }
+
+    private suspend fun failAndExit(@StringRes messageRes: Int) = withContext(Dispatchers.Main) {
+        host.showScreenSaverMessage(messageRes)
+        host.exitScreenSaver()
+    }
+
+    private suspend fun setInitialAssets(assets: List<Asset>, loadMore: LoadMore?) = withContext(Dispatchers.Main) {
+        if (assets.isEmpty()) {
+            host.showScreenSaverMessage(R.string.no_assets_for_screensaver, longDuration = true)
+            if (host.exitWhenNothingToShow) {
+                host.exitScreenSaver()
+            }
+        } else {
+            host.onScreenSaverConfigurationReady(
+                buildScreenSaverConfiguration(assets, loadMore, scope, favoriteService)
+            )
+        }
+    }
+
+    companion object {
+        private const val PAGE_COUNT = 100
+    }
+}

--- a/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverPreviewFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverPreviewFragment.kt
@@ -1,0 +1,129 @@
+package nl.giejay.android.tv.immich.screensaver
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Bundle
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.navigation.fragment.findNavController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import nl.giejay.android.tv.immich.R
+import nl.giejay.android.tv.immich.api.ApiClient
+import nl.giejay.android.tv.immich.shared.prefs.API_KEY
+import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
+import nl.giejay.mediaslider.config.MediaSliderConfiguration
+import nl.giejay.mediaslider.view.MediaSliderFragment
+import nl.giejay.mediaslider.view.MediaSliderView
+import timber.log.Timber
+
+/**
+ * The screensaver has no interactive controls, so the preview must not have any either: BACK
+ * leaves the preview and the volume keys reach the system, every other key is swallowed before
+ * [nl.giejay.mediaslider.view.MediaSliderController] can act on it.
+ */
+internal class ScreenSaverPreviewSliderView(context: Context) : MediaSliderView(context) {
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean = when (event.keyCode) {
+        KeyEvent.KEYCODE_BACK,
+        KeyEvent.KEYCODE_VOLUME_UP,
+        KeyEvent.KEYCODE_VOLUME_DOWN,
+        KeyEvent.KEYCODE_VOLUME_MUTE -> false // let it bubble up to the activity / system
+
+        else -> true // consumed here, never reaches the slider controller or the pager
+    }
+}
+
+/**
+ * Renders the configured screensaver full screen inside the app, so the settings can be checked
+ * without registering the app as the system daydream and waiting for the TV to go idle.
+ *
+ * Everything shown here comes from [ScreenSaverAssetLoader], the same loader the real
+ * [ScreenSaverService] uses, so the preview cannot drift away from the actual screensaver.
+ */
+class ScreenSaverPreviewFragment : MediaSliderFragment(), ScreenSaverAssetLoader.Host {
+    private var ioScope = CoroutineScope(Job() + Dispatchers.IO)
+    private var sliderView: ScreenSaverPreviewSliderView? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ScreenSaverPreviewSliderView(requireContext()).also {
+            // The dream keeps the screen alive by itself. Without this the TV dims mid preview,
+            // or the idle timeout starts the real screensaver on top of it.
+            it.keepScreenOn = true
+            sliderView = it
+        }
+    }
+
+    @SuppressLint("UnsafeOptInUsageError")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Timber.i("Loading ${this.javaClass.simpleName}")
+
+        if (!PreferenceManager.isLoggedId()) {
+            showScreenSaverMessage(R.string.screensaver_not_possible)
+            exitScreenSaver()
+            return
+        }
+
+        ioScope = CoroutineScope(Job() + Dispatchers.IO)
+        sliderView?.setDefaultExoFactory(
+            DefaultHttpDataSource.Factory()
+                .setDefaultRequestProperties(mapOf("x-api-key" to PreferenceManager.get(API_KEY)))
+        )
+        ScreenSaverAssetLoader(
+            ioScope,
+            ApiClient.getClient(screenSaverApiClientConfig()),
+            this
+        ).start()
+    }
+
+    override fun onPause() {
+        // super tears the player down and never rebuilds it, so leave rather than come back to a
+        // dead preview.
+        super.onPause()
+        if (isAdded) {
+            findNavController().popBackStack()
+        }
+    }
+
+    override fun onDestroyView() {
+        ioScope.cancel()
+        sliderView = null
+        super.onDestroyView()
+    }
+
+    // --- ScreenSaverAssetLoader.Host ---
+
+    override val exitWhenNothingToShow: Boolean = true
+
+    override fun showScreenSaverMessage(messageRes: Int, longDuration: Boolean) {
+        val context = context ?: return
+        Toast.makeText(
+            context,
+            getString(messageRes),
+            if (longDuration) Toast.LENGTH_LONG else Toast.LENGTH_SHORT
+        ).show()
+    }
+
+    override fun exitScreenSaver() {
+        if (isAdded) {
+            findNavController().popBackStack()
+        }
+    }
+
+    override fun onScreenSaverConfigurationReady(configuration: MediaSliderConfiguration) {
+        // null once the view is gone: the user left while the assets were still loading
+        val slider = sliderView ?: return
+        slider.loadMediaSliderView(configuration)
+        slider.toggleSlideshow(false)
+    }
+}

--- a/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverService.kt
@@ -5,90 +5,33 @@ import android.service.dreams.DreamService
 import android.view.KeyEvent
 import android.widget.Toast
 import androidx.media3.datasource.DefaultHttpDataSource
-import arrow.core.Either
-import arrow.core.getOrElse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import nl.giejay.android.tv.immich.R
 import nl.giejay.android.tv.immich.api.ApiClient
-import nl.giejay.android.tv.immich.api.ApiClientConfig
-import nl.giejay.android.tv.immich.api.model.Asset
-import nl.giejay.android.tv.immich.api.model.AssetResponse
 import nl.giejay.android.tv.immich.shared.prefs.API_KEY
-import nl.giejay.android.tv.immich.shared.prefs.ContentType
-import nl.giejay.android.tv.immich.shared.prefs.DEBUG_MODE
-import nl.giejay.android.tv.immich.shared.prefs.DISABLE_SSL_VERIFICATION
-import nl.giejay.android.tv.immich.shared.prefs.EXCLUDE_ASSETS_IN_ALBUM
-import nl.giejay.android.tv.immich.shared.prefs.MetaDataScreen
 import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ALBUMS
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ANIMATE_ASSET_SLIDE
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_INCLUDE_VIDEOS
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_INTERVAL
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_PLAY_SOUND
-import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_TYPE
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ANIMATION_SPEED
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_DPAD_SEEK_IN_VIDEO
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_FORCE_ORIGINAL_VIDEO
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_GLIDE_TRANSFORMATION
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_PAN_EFFECT
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_EFFECT
-import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
-import nl.giejay.android.tv.immich.shared.util.Utils.pmap
-import nl.giejay.android.tv.immich.shared.util.toSliderItems
-import nl.giejay.android.tv.immich.slider.FavoriteService
 import nl.giejay.mediaslider.config.MediaSliderConfiguration
-import nl.giejay.mediaslider.util.LoadMore
-import nl.giejay.mediaslider.util.LoadMoreResult
 import nl.giejay.mediaslider.util.MediaSliderListener
 import nl.giejay.mediaslider.view.MediaSliderView
 import timber.log.Timber
 
-// internal so app/src/test can call it directly without instantiating ScreenSaverService
-internal fun <T> Either<String, T>.getOrElseLogged(logContext: String, default: T): T =
-    this.onLeft { error -> Timber.w("Failed to load assets for %s: %s", logContext, error) }
-        .getOrElse { default }
-
-internal fun filterExcludedAssets(assets: List<Asset>, excludedAssetIds: Set<String>): List<Asset> =
-    assets.filter { asset -> asset.tags?.none { it.name == "exclude_immich_tv" } ?: true }
-        .filterNot { excludedAssetIds.contains(it.id) }
-
-class ScreenSaverService : DreamService(), MediaSliderListener {
+class ScreenSaverService : DreamService(), MediaSliderListener, ScreenSaverAssetLoader.Host {
     private var ioScope = CoroutineScope(Job() + Dispatchers.IO)
-    private lateinit var apiClient: ApiClient
-    private val favoriteService = FavoriteService()
     private var mediaSliderView: MediaSliderView? = null
-    private var currentPage = 0
-    private var excludedAssetIds: Set<String> = emptySet()
-    private val filteredAssetLoader = FilteredAssetLoader(
-        filterAssets = { filterExcludedAssets(it, excludedAssetIds) }
-    )
 
     @SuppressLint("UnsafeOptInUsageError")
     override fun onDreamingStarted() {
         ioScope = CoroutineScope(Job() + Dispatchers.IO)
-        filteredAssetLoader.reset()
         Timber.i("Starting screensaver")
         if (!PreferenceManager.isLoggedId()) {
-            showErrorMessage(getString(R.string.screensaver_not_possible))
+            showScreenSaverMessage(R.string.screensaver_not_possible)
             finish()
             return
         }
         val apiKey = PreferenceManager.get(API_KEY)
-        val config = ApiClientConfig(
-            PreferenceManager.hostName,
-            apiKey,
-            PreferenceManager.get(DISABLE_SSL_VERIFICATION),
-            PreferenceManager.get(DEBUG_MODE)
-        )
-        apiClient = ApiClient.getClient(config)
         mediaSliderView = MediaSliderView(this)
         mediaSliderView!!.setDefaultExoFactory(
             DefaultHttpDataSource.Factory()
@@ -96,28 +39,11 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
         )
         setContentView(mediaSliderView)
         isInteractive = true
-        ioScope.launch {
-            val excludedAlbums = PreferenceManager.get(EXCLUDE_ASSETS_IN_ALBUM)
-            if (excludedAlbums.isNotEmpty()) {
-                excludedAssetIds = apiClient.listAssetsFromAlbum(excludedAlbums.toList(), pageCount = 5000)
-                    .getOrElse { AssetResponse(emptyList(), false) }
-                    .assets
-                    .map { it.id }
-                    .toSet()
-            }
-
-            if (ScreenSaverType.ALBUMS == PreferenceManager.get(SCREENSAVER_TYPE)) {
-                loadImagesFromAlbums(PreferenceManager.get(SCREENSAVER_ALBUMS).toList())
-            } else {
-                val screenSaverType = PreferenceManager.get(SCREENSAVER_TYPE)
-                filteredAssetLoader.load { loadNextAssets(screenSaverType) }.map { response ->
-                    setInitialAssets(
-                        response.assets,
-                        if (response.canLoadMore) createLoadMore { loadNextAssets(screenSaverType) } else null
-                    )
-                }
-            }
-        }
+        ScreenSaverAssetLoader(
+            ioScope,
+            ApiClient.getClient(screenSaverApiClientConfig()),
+            this
+        ).start()
     }
 
     override fun onDreamingStopped() {
@@ -126,144 +52,21 @@ class ScreenSaverService : DreamService(), MediaSliderListener {
         super.onDreamingStopped()
     }
 
-    private suspend fun loadNextAssets(screenSaverType: ScreenSaverType): Either<String, AssetResponse> {
-        val contentType = if (PreferenceManager.get(SCREENSAVER_INCLUDE_VIDEOS)) ContentType.ALL else ContentType.IMAGE
-        val page = currentPage
-        currentPage += 1
-        return when (screenSaverType) {
-            ScreenSaverType.RECENT -> apiClient.recentAssets(page, PAGE_COUNT, contentType = contentType)
-            ScreenSaverType.SIMILAR_TIME_PERIOD -> apiClient.similarAssets(page, PAGE_COUNT, contentType = contentType)
-            else -> apiClient.listAssets(page, PAGE_COUNT, true, contentType = contentType)
-        }
-    }
-
-    private fun createLoadMore(fetch: suspend () -> Either<String, AssetResponse>): LoadMore = suspend {
-        filteredAssetLoader.load(fetch).fold(
-            { error ->
-                Timber.w("Failed to load more screensaver assets: %s", error)
-                LoadMoreResult(emptyList(), false)
-            },
-            { response ->
-                LoadMoreResult(
-                    response.assets.toSliderItems(false, PreferenceManager.get(SLIDER_MERGE_PORTRAIT_PHOTOS)),
-                    response.canLoadMore
-                )
-            }
-        )
-    }
-
-    private suspend fun loadImagesFromAlbums(albums: List<String>) {
-        try {
-            if (albums.isNotEmpty()) {
-                var loadRandomAssets = true
-                val initialResponse = filteredAssetLoader.load {
-                    if (loadRandomAssets) {
-                        loadRandomAssets = false
-                        loadNextAssetsFromAlbums(albums, random = true).fold(
-                            {
-                                Timber.w("Could not load random assets for albums $albums, falling back to all album assets")
-                                loadNextAssetsFromAlbums(albums, random = false)
-                            },
-                            { Either.Right(it) }
-                        )
-                    } else {
-                        Timber.w("Random album sample was empty after exclusions for albums $albums, checking their complete asset lists")
-                        loadNextAssetsFromAlbums(albums, random = false)
-                    }
-                }.getOrElse { throw IllegalStateException(it) }
-
-                setInitialAssets(
-                    initialResponse.assets,
-                    if (initialResponse.canLoadMore) {
-                        createLoadMore { loadNextAssetsFromAlbums(albums, random = false) }
-                    } else null
-                )
-            } else {
-                showErrorMessageMainScope(getString(R.string.set_albums_screensaver_error))
-                finish()
-            }
-        } catch (e: Exception) {
-            Timber.e(e, "Could not fetch assets from Immich for Screensaver")
-            showErrorMessageMainScope(getString(R.string.could_not_load_assets))
-            finish()
-        }
-    }
-
-    private suspend fun loadNextAssetsFromAlbums(albums: List<String>, random: Boolean = false): Either<String, AssetResponse> {
-        val contentType = if (PreferenceManager.get(SCREENSAVER_INCLUDE_VIDEOS)) ContentType.ALL else ContentType.IMAGE
-        if (random) {
-            val pageCount = (50 / albums.size).coerceAtLeast(1)
-            val responses = albums.pmap { albumId ->
-                apiClient.listAssets(
-                    page = 1,
-                    pageCount = pageCount,
-                    random = true,
-                    contentType = contentType,
-                    albumIds = listOf(albumId)
-                )
-            }
-            responses.firstOrNull { it.isLeft() }?.let { return it }
-            return Either.Right(AssetResponse(
-                responses.flatMap { it.getOrElse { AssetResponse(emptyList(), true) }.assets }.shuffled(),
-                true
-            ))
-        } else {
-            return apiClient.listAssetsFromAlbum(albums, contentType, pageCount = 1000)
-        }
-    }
-
-    private suspend fun showErrorMessageMainScope(errorMessage: String) {
-        withContext(Dispatchers.Main) {
-            showErrorMessage(errorMessage)
-        }
-    }
-
-    private fun showErrorMessage(errorMessage: String) {
+    override fun showScreenSaverMessage(messageRes: Int, longDuration: Boolean) {
         Toast.makeText(
-            this@ScreenSaverService,
-            errorMessage,
-            Toast.LENGTH_SHORT
+            this,
+            getString(messageRes),
+            if (longDuration) Toast.LENGTH_LONG else Toast.LENGTH_SHORT
         ).show()
     }
 
-    private suspend fun setInitialAssets(assets: List<Asset>, loadMore: LoadMore?) = withContext(Dispatchers.Main) {
-        if (assets.isEmpty()) {
-            Toast.makeText(this@ScreenSaverService,
-                getString(R.string.no_assets_for_screensaver),
-                Toast.LENGTH_LONG).show()
-        } else {
-            val enabledPlugins = PreferenceManager.createEnabledSliderPlugins(ioScope, favoriteService)
-            mediaSliderView?.loadMediaSliderView(
-                MediaSliderConfiguration(
-                    0,
-                    PreferenceManager.get(SCREENSAVER_INTERVAL),
-                    PreferenceManager.get(SLIDER_ONLY_USE_THUMBNAILS),
-                    PreferenceManager.get(SCREENSAVER_PLAY_SOUND),
-                    assets.toSliderItems(keepOrder = false, mergePortrait = PreferenceManager.get(SLIDER_MERGE_PORTRAIT_PHOTOS)),
-                    loadMore,
-                    animationSpeedMillis = PreferenceManager.get(SLIDER_ANIMATION_SPEED),
-                    maxCutOffHeight = PreferenceManager.get(SLIDER_MAX_CUT_OFF_HEIGHT),
-                    maxCutOffWidth = PreferenceManager.get(SLIDER_MAX_CUT_OFF_HEIGHT),
-                    glideTransformation = PreferenceManager.get(SLIDER_GLIDE_TRANSFORMATION),
-                    enableSlideAnimation = PreferenceManager.get(SCREENSAVER_ANIMATE_ASSET_SLIDE),
-                    gradiantOverlay = true,
-                    metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.SCREENSAVER),
-                    zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS),
-                    zoomEffectPercent = PreferenceManager.get(SLIDER_ZOOM_EFFECT),
-                    panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
-                    useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO),
-                    dpadSeeksInVideo = PreferenceManager.get(SLIDER_DPAD_SEEK_IN_VIDEO),
-                    controllerPlugins = enabledPlugins.controllerPlugins,
-                    viewPlugins = enabledPlugins.viewPlugins,
-                    keyEventPlugins = enabledPlugins.keyEventPlugins
-                )
-            )
-            mediaSliderView?.toggleSlideshow(false)
-        }
+    override fun exitScreenSaver() {
+        finish()
     }
 
-    companion object ScreenSaverService {
-        private const val PAGE_COUNT = 100
+    override fun onScreenSaverConfigurationReady(configuration: MediaSliderConfiguration) {
+        mediaSliderView?.loadMediaSliderView(configuration)
+        mediaSliderView?.toggleSlideshow(false)
     }
 
     override fun onButtonPressed(keyEvent: KeyEvent): Boolean {

--- a/app/src/main/java/nl/giejay/android/tv/immich/settings/SettingsFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/settings/SettingsFragment.kt
@@ -1,6 +1,7 @@
 package nl.giejay.android.tv.immich.settings
 
 import android.app.Activity
+import android.widget.Toast
 import androidx.leanback.app.RowsSupportFragment
 import androidx.leanback.widget.ArrayObjectAdapter
 import androidx.leanback.widget.HeaderItem
@@ -11,8 +12,12 @@ import androidx.navigation.fragment.findNavController
 import nl.giejay.android.tv.immich.ImmichApplication
 import nl.giejay.android.tv.immich.R
 import nl.giejay.android.tv.immich.home.HomeFragmentDirections
+import nl.giejay.android.tv.immich.screensaver.ScreenSaverType
 import nl.giejay.android.tv.immich.shared.donate.DonateService
 import nl.giejay.android.tv.immich.shared.prefs.DebugPrefScreen
+import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
+import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ALBUMS
+import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_TYPE
 import nl.giejay.android.tv.immich.shared.prefs.ScreensaverPrefScreen
 import nl.giejay.android.tv.immich.shared.prefs.ViewPrefScreen
 
@@ -75,6 +80,29 @@ class SettingsFragment : RowsSupportFragment() {
                             findNavController().navigate(
                                 HomeFragmentDirections.actionGlobalToSettingsDialog(ScreensaverPrefScreen.key)
                             )
+                        },
+                        SettingsCard(
+                            ImmichApplication.appContext!!.getString(R.string.screensaver_preview),
+                            null,
+                            "screensaver_preview",
+                            "view",
+                            "view"
+                        ) {
+                            // Same guard as SCREENSAVER_SET: previewing albums without albums
+                            // selected would only ever show a black screen.
+                            if (PreferenceManager.get(SCREENSAVER_TYPE) == ScreenSaverType.ALBUMS &&
+                                PreferenceManager.get(SCREENSAVER_ALBUMS).isEmpty()
+                            ) {
+                                Toast.makeText(
+                                    requireContext(),
+                                    getString(R.string.screensaver_set_select_albums_first),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            } else {
+                                findNavController().navigate(
+                                    HomeFragmentDirections.actionGlobalScreensaverPreview()
+                                )
+                            }
                         },
                         SettingsCard(
                             ImmichApplication.appContext!!.getString(R.string.debug),

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -49,6 +49,10 @@
         android:id="@+id/action_to_metadata_fragment"
         app:destination="@id/metaDataCustomizer" />
 
+    <action
+        android:id="@+id/action_global_screensaver_preview"
+        app:destination="@id/screenSaverPreviewFragment" />
+
     <!--    <fragment-->
     <!--        android:id="@+id/playbackFragment"-->
     <!--        android:name="nl.giejay.android.tv.immich.playback.PlaybackFragment"-->
@@ -111,6 +115,11 @@
         android:name="nl.giejay.android.tv.immich.assets.AllAssetFragment"
         android:label="AllAssetsFragment">
     </fragment>
+
+    <fragment
+        android:id="@+id/screenSaverPreviewFragment"
+        android:name="nl.giejay.android.tv.immich.screensaver.ScreenSaverPreviewFragment"
+        android:label="ScreenSaverPreview" />
 
     <fragment
         android:id="@+id/photoSlider"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -130,6 +130,7 @@
     <string name="play_sound_screensaver">Lire le son des vidéos pendant l’écran de veille</string>
     <string name="screensaver_type">Type d’écran de veille</string>
     <string name="screensaver_type_desc">Ce qui doit être affiché : albums, aléatoire, récent, etc.</string>
+    <string name="screensaver_preview">Aperçu</string>
 
     <!-- Slider/viewer preferences -->
     <string name="interval_slideshow">Intervalle du diaporama</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -131,6 +131,7 @@
     <string name="play_sound_screensaver">Проигрывать звук видео в заставке</string>
     <string name="screensaver_type">Тип заставки</string>
     <string name="screensaver_type_desc">Что показывать: альбомы, случайные, недавние и т.д.</string>
+    <string name="screensaver_preview">Предпросмотр</string>
 
     <!-- Slider/viewer preferences -->
     <string name="interval_slideshow">Интервал слайд-шоу</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@
     <string name="play_sound_screensaver">Play sound of videos during screensaver</string>
     <string name="screensaver_type">Screensaver type</string>
     <string name="screensaver_type_desc">What to show: albums, random, recent etc.</string>
+    <string name="screensaver_preview">Preview</string>
 
     <!-- Slider/viewer preferences -->
     <string name="interval_slideshow">Slideshow interval</string>

--- a/app/src/test/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverAssetFilterTest.kt
+++ b/app/src/test/java/nl/giejay/android/tv/immich/screensaver/ScreenSaverAssetFilterTest.kt
@@ -1,0 +1,77 @@
+package nl.giejay.android.tv.immich.screensaver
+
+import com.google.common.truth.Truth.assertThat
+import nl.giejay.android.tv.immich.api.model.Asset
+import nl.giejay.android.tv.immich.api.model.Tag
+import org.junit.Test
+import java.util.Date
+
+/**
+ * Covers the asset filtering shared by the DreamService and the in-app screensaver preview.
+ * Pure JVM on purpose: no Android, no PreferenceManager, no Robolectric.
+ */
+class ScreenSaverAssetFilterTest {
+
+    private fun tag(name: String) = Tag(null, Date(0), name, name)
+
+    private fun asset(id: String, tags: List<Tag>?) = Asset(
+        id = id,
+        type = "IMAGE",
+        deviceAssetId = null,
+        exifInfo = null,
+        fileModifiedAt = null,
+        albumName = null,
+        people = null,
+        tags = tags,
+        originalPath = null,
+        originalFileName = null
+    )
+
+    @Test
+    fun `asset tagged exclude_immich_tv is excluded`() {
+        val tagged = asset("a", listOf(tag("exclude_immich_tv")))
+
+        assertThat(filterExcludedAssets(listOf(tagged), emptySet())).isEmpty()
+    }
+
+    @Test
+    fun `asset with null tags is kept`() {
+        val untagged = asset("a", null)
+
+        assertThat(filterExcludedAssets(listOf(untagged), emptySet())).containsExactly(untagged)
+    }
+
+    @Test
+    fun `asset with empty tag list is kept`() {
+        val untagged = asset("a", emptyList())
+
+        assertThat(filterExcludedAssets(listOf(untagged), emptySet())).containsExactly(untagged)
+    }
+
+    @Test
+    fun `asset with unrelated tags is kept`() {
+        val holiday = asset("a", listOf(tag("holiday"), tag("2024")))
+
+        assertThat(filterExcludedAssets(listOf(holiday), emptySet())).containsExactly(holiday)
+    }
+
+    @Test
+    fun `asset in an excluded album is excluded`() {
+        val kept = asset("keep", null)
+        val excluded = asset("drop", null)
+
+        assertThat(filterExcludedAssets(listOf(kept, excluded), setOf("drop")))
+            .containsExactly(kept)
+    }
+
+    @Test
+    fun `asset excluded by both rules is dropped once and survivor order is preserved`() {
+        val first = asset("1", null)
+        val both = asset("2", listOf(tag("exclude_immich_tv")))
+        val second = asset("3", emptyList())
+
+        val result = filterExcludedAssets(listOf(first, both, second), setOf("2"))
+
+        assertThat(result).containsExactly(first, second).inOrder()
+    }
+}


### PR DESCRIPTION
## What

Adds a **Preview** card to Home → Settings that renders the configured screensaver full screen inside the app.

Today the only way to see what your screensaver settings actually produce is to register the app as the system daydream and then wait for the TV to idle. That makes tuning interval, Ken Burns zoom/pan, slide animation, metadata overlay and album selection a slow guess-and-check loop — and on devices where the daydream picker is unreachable (the case `screensaver_adb.xml` already exists for), it's close to impossible.

## How

The screensaver's asset loading and `MediaSliderConfiguration` assembly are extracted from `ScreenSaverService` into a `Context`-agnostic `ScreenSaverAssetLoader`, which both the `DreamService` and the new `ScreenSaverPreviewFragment` drive. Because there is now exactly **one** `MediaSliderConfiguration` literal for the screensaver, the preview cannot drift from the real thing.

Split into two commits so the risky part is isolated and revertable:

1. **`refactor`** — pure move + a `Host` interface. Reviewable as a diff-of-a-move; verified to compile standalone.
2. **`feat`** — the preview fragment, nav destination, settings card and strings.

### Behaviour

- Full screen and pixel-identical — no badge, hint or chrome of any kind.
- **BACK** leaves; volume keys reach the system; every other key is swallowed, matching the screensaver's lack of interactive controls. Implemented by overriding `dispatchKeyEvent` on a `MediaSliderView` subclass, so **no lines of `:mediaslider:mediaslider` are touched** and the real screensaver's key handling cannot regress.
- `keepScreenOn` while previewing, otherwise the TV dims or the idle timeout starts the real screensaver on top of the preview. Uses `View.setKeepScreenOn` rather than the controller's window flags, since `stopPlayer()` clears those on every page change.
- Leaves rather than sitting on black when there's nothing to show, and closes itself when backgrounded (the player isn't rebuilt on resume). Both are preview-only, via `Host.exitWhenNothingToShow` — **the dream's existing behaviour is unchanged**.
- Previewing `ALBUMS` with no albums selected shows the same hint as "Set screensaver" instead of navigating to a black screen.

### Deliberately preserved

- The `maxCutOffWidth = SLIDER_MAX_CUT_OFF_HEIGHT` quirk in the screensaver config, kept verbatim rather than "fixed", so the dream's output is bit-for-bit unchanged.
- Prefs are still read at their original call sites (including per-page inside the `loadMore` lambda).
- The silent-`Left` and empty-assets-no-exit paths, for the dream.

### One intentional delta

`loadImagesFromAlbums` previously called `finish()` from the IO thread while only the toast hopped to Main. Both now run on Main — safer for the dream, and required for a fragment host.

## Testing

`./gradlew clean test assembleDebug` → green, 123 tests, 0 failures. Adds `ScreenSaverAssetFilterTest` (pure JVM) over the extracted filtering; the existing `ScreenSaverServiceLoggingTest` compiles unchanged.

Verified on an Android TV 14 emulator against a local Immich v3.1.0 with 169 assets (168 photos + 1 video), dated to hit each screensaver type:

| | |
|---|---|
| Preview renders, auto-advances, metadata + gradient | ✅ |
| OK / D-pad / MENU / PLAY inert, no controller overlay | ✅ |
| BACK exits; keep-screen-on released, no flag leak | ✅ |
| Albums-empty guard; unreachable server exits cleanly | ✅ |
| `loadMore` paging | ✅ 24 sequential page fetches |
| Interval accuracy | ✅ 6 gaps of 6.17–6.20s at a configured 6s |
| Ken Burns zoom/pan, slide animation | ✅ |
| `RANDOM` / `RECENT` / `SIMILAR_TIME_PERIOD` / `ALBUMS` | ✅ all four |
| **Real `DreamService` regression** | ✅ renders identically; exits on OK with `finished self` |

Not verified: audible video sound — sound on/off is an ExoPlayer volume scalar and the emulator ran with `-no-audio`.

### Rebase onto latest main

Rebased onto `main` (the `ScreenSaverService` conflict resolved by adopting main's `FilteredAssetLoader` retry integration and the `createEnabledSliderPlugins` / `dpadSeeksInVideo` config), then re-verified end-to-end on the Android TV 14 emulator against a fresh local Immich v3.1.0:

| | |
|---|---|
| Login + timeline load | ✅ |
| Preview renders, auto-advances, metadata overlay | ✅ |
| CENTER / D-pad / MEDIA_PLAY_PAUSE inert | ✅ |
| BACK exits to settings | ✅ |
| Albums-empty guard toast, no navigation | ✅ |
| Backgrounded → closes; resume lands on settings | ✅ |

## Note

The `values-ru` and `values-fr` strings for the new `screensaver_preview` key are best-effort and would benefit from a native speaker's eye.