### PR TITLE
feat(mediaslider): add Enter/Back details overlay via key plugin

### DIFF
--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/FolderFragment.kt
@@ -24,6 +24,7 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_PAN_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_DETAILS_ALWAYS_ON
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_SHOW_DATE_TOP_LEFT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_EFFECT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
@@ -112,7 +113,8 @@ class FolderFragment : VerticalCardGridFragment<Item>() {
                 panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
                 useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO),
                 dpadSeeksInVideo = PreferenceManager.get(SLIDER_DPAD_SEEK_IN_VIDEO),
-                showDateTopLeft = PreferenceManager.get(SLIDER_SHOW_DATE_TOP_LEFT)
+                showDateTopLeft = PreferenceManager.get(SLIDER_SHOW_DATE_TOP_LEFT),
+                detailsAlwaysOn = PreferenceManager.get(SLIDER_DETAILS_ALWAYS_ON)
             )
             sliderViewModel.configuration = config
             findNavController().navigate(

--- a/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/assets/GenericAssetFragment.kt
@@ -36,6 +36,7 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MERGE_PORTRAIT_PHOTOS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_PAN_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_DETAILS_ALWAYS_ON
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_SHOW_DATE_TOP_LEFT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_EFFECT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
@@ -170,7 +171,8 @@ abstract class GenericAssetFragment : VerticalCardGridFragment<Asset>() {
                     panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
                     useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO),
                     dpadSeeksInVideo = PreferenceManager.get(SLIDER_DPAD_SEEK_IN_VIDEO),
-                    showDateTopLeft = PreferenceManager.get(SLIDER_SHOW_DATE_TOP_LEFT)
+                    showDateTopLeft = PreferenceManager.get(SLIDER_SHOW_DATE_TOP_LEFT),
+                    detailsAlwaysOn = PreferenceManager.get(SLIDER_DETAILS_ALWAYS_ON)
                 )
                 sliderViewModel.configuration = config
                 findNavController().navigate(AlbumDetailsFragmentDirections.actionToPhotoSlider())

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/PreferenceManager.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/PreferenceManager.kt
@@ -13,6 +13,7 @@ import nl.giejay.mediaslider.adapter.MetaDataMediaCount
 import nl.giejay.mediaslider.adapter.MetaDataSliderItem
 import nl.giejay.mediaslider.model.MetaDataType
 import nl.giejay.mediaslider.plugin.DateOverlayViewPlugin
+import nl.giejay.mediaslider.plugin.DetailsOverlayKeyPlugin
 import nl.giejay.mediaslider.plugin.ExternalPlayerButtonControllerPlugin
 import nl.giejay.mediaslider.plugin.MediaRemoteControlsKeyEventPlugin
 import nl.giejay.mediaslider.plugin.MetadataViewPlugin
@@ -180,10 +181,12 @@ object PreferenceManager {
      * Builds a fresh set of Immich slider plugins for one slider session.
      * [MetadataViewPlugin] is shared across view + controller lists.
      * [DateOverlayViewPlugin] optionally renders DATE at the top of the slider.
+     * [DetailsOverlayKeyPlugin] handles Enter/Back for bottom details (before remote on the key list).
      * [MediaRemoteControlsKeyEventPlugin] handles remote/D-pad seek and related keys.
      */
     fun createEnabledSliderPlugins(scope: CoroutineScope, favoriteService: FavoriteService): EnabledSliderPlugins {
         val metadataPlugin = MetadataViewPlugin()
+        val detailsKeyPlugin = DetailsOverlayKeyPlugin(metadataPlugin)
         val remoteControlsPlugin = MediaRemoteControlsKeyEventPlugin()
         return EnabledSliderPlugins(
             controllerPlugins = listOf(
@@ -192,7 +195,7 @@ object PreferenceManager {
                 metadataPlugin
             ),
             viewPlugins = listOf(metadataPlugin, DateOverlayViewPlugin()),
-            keyEventPlugins = listOf(remoteControlsPlugin)
+            keyEventPlugins = listOf(detailsKeyPlugin, remoteControlsPlugin)
         )
     }
 

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
@@ -200,6 +200,10 @@ data object SLIDER_SHOW_DATE_TOP_LEFT : BooleanPref(true,
     ImmichApplication.appContext!!.getString(R.string.show_date_top_left),
     ImmichApplication.appContext!!.getString(R.string.show_date_top_left_viewer_desc))
 
+data object SLIDER_DETAILS_ALWAYS_ON : BooleanPref(false,
+    ImmichApplication.appContext!!.getString(R.string.details_always_on),
+    ImmichApplication.appContext!!.getString(R.string.details_always_on_desc))
+
 data object SLIDER_SHOW_CITY : BooleanPref(true,
     ImmichApplication.appContext!!.getString(R.string.show_city),
     ImmichApplication.appContext!!.getString(R.string.show_city_desc))
@@ -493,6 +497,7 @@ data object ViewSlideshowPrefScreen : PrefScreen(ImmichApplication.appContext!!.
             SLIDER_INTERVAL,
             SLIDER_ANIMATION_SPEED,
             SLIDER_SHOW_DATE_TOP_LEFT,
+            SLIDER_DETAILS_ALWAYS_ON,
             SLIDER_METADATA_CUSTOMIZER
         ))
     )

--- a/app/src/main/java/nl/giejay/android/tv/immich/timeline/TimelineFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/timeline/TimelineFragment.kt
@@ -51,6 +51,7 @@ import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_PAN_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_DETAILS_ALWAYS_ON
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_SHOW_DATE_TOP_LEFT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_EFFECT
 import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
@@ -1064,7 +1065,8 @@ class TimelineFragment : BrandedSupportFragment(), BrowseSupportFragment.MainFra
                     panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
                     useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO),
                     dpadSeeksInVideo = PreferenceManager.get(SLIDER_DPAD_SEEK_IN_VIDEO),
-                    showDateTopLeft = PreferenceManager.get(SLIDER_SHOW_DATE_TOP_LEFT)
+                    showDateTopLeft = PreferenceManager.get(SLIDER_SHOW_DATE_TOP_LEFT),
+                    detailsAlwaysOn = PreferenceManager.get(SLIDER_DETAILS_ALWAYS_ON)
                 )
                 sliderViewModel.configuration = config
                 findNavController().navigate(
@@ -1107,7 +1109,8 @@ class TimelineFragment : BrandedSupportFragment(), BrowseSupportFragment.MainFra
             panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
             useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO),
             dpadSeeksInVideo = PreferenceManager.get(SLIDER_DPAD_SEEK_IN_VIDEO),
-            showDateTopLeft = PreferenceManager.get(SLIDER_SHOW_DATE_TOP_LEFT)
+            showDateTopLeft = PreferenceManager.get(SLIDER_SHOW_DATE_TOP_LEFT),
+            detailsAlwaysOn = PreferenceManager.get(SLIDER_DETAILS_ALWAYS_ON)
         )
         sliderViewModel.configuration = config
         findNavController().navigate(

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -146,6 +146,8 @@
     <string name="show_date_top_left">Afficher la date en haut à gauche</string>
     <string name="show_date_top_left_viewer_desc">Affiche la date de l’élément en overlay en haut à gauche dans la visionneuse. Indépendant des métadonnées en bas.</string>
     <string name="show_date_top_left_screensaver_desc">Affiche la date de l’élément en overlay en haut à gauche dans l’écran de veille. Indépendant des métadonnées en bas.</string>
+    <string name="details_always_on">Toujours afficher les détails</string>
+    <string name="details_always_on_desc">Garde les métadonnées du bas toujours visibles dans la visionneuse. Si désactivé, Entrée les affiche et Retour les masque après les contrôles multimédia.</string>
     <string name="show_city">Afficher la ville</string>
     <string name="show_city_desc">Afficher la ville de l’élément dans le diaporama</string>
     <string name="customize_metadata_viewer">Personnaliser les métadonnées</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -147,6 +147,8 @@
     <string name="show_date_top_left">Показывать дату сверху слева</string>
     <string name="show_date_top_left_viewer_desc">Показывать дату элемента в оверлее сверху слева в просмотрщике. Независимо от нижних метаданных.</string>
     <string name="show_date_top_left_screensaver_desc">Показывать дату элемента в оверлее сверху слева в заставке. Независимо от нижних метаданных.</string>
+    <string name="details_always_on">Всегда показывать детали</string>
+    <string name="details_always_on_desc">Держать нижние метаданные всегда видимыми в просмотрщике. Если выключено, Enter показывает их, а Назад скрывает после медиаконтролей.</string>
     <string name="show_city">Показывать город</string>
     <string name="show_city_desc">Показывать город элемента в слайд-шоу</string>
     <string name="customize_metadata_viewer">Настроить метаданные</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,6 +146,8 @@
     <string name="show_date_top_left">Show date top-left</string>
     <string name="show_date_top_left_viewer_desc">Show the asset date as a top-left overlay in the photo/video viewer. Independent of bottom metadata.</string>
     <string name="show_date_top_left_screensaver_desc">Show the asset date as a top-left overlay in the screensaver. Independent of bottom metadata.</string>
+    <string name="details_always_on">Always show details</string>
+    <string name="details_always_on_desc">Keep bottom metadata always visible in the viewer. When off, Enter shows details and Back hides them after the media controls.</string>
     <string name="show_city">Show city</string>
     <string name="show_city_desc">Show city of asset in slideshow</string>
     <string name="customize_metadata_viewer">Customize metadata</string>

--- a/mediaslider/mediaslider/PLUGIN_SYSTEM.md
+++ b/mediaslider/mediaslider/PLUGIN_SYSTEM.md
@@ -112,9 +112,9 @@ MediaSliderConfiguration(
 
 ## Built-in Plugins
 
-- `MetadataViewPlugin`: Renders asset metadata (description, date, etc.).
+- `MetadataViewPlugin`: Renders asset metadata (description, date, etc.). In the viewer, starts hidden unless `MediaSliderConfiguration.detailsAlwaysOn` is true.
 - `DateOverlayViewPlugin`: Optional top-of-screen DATE overlay with a dark scrim (`MediaSliderConfiguration.showDateTopLeft`). Bottom DATE metadata is unchanged.
-- `DetailsOverlayKeyPlugin`: Viewer Enter/Back for bottom details (register before [MediaRemoteControlsKeyEventPlugin] on the key list). Screensaver keeps metadata always on.
+- `DetailsOverlayKeyPlugin`: Viewer Enter/Back for bottom details (register before [MediaRemoteControlsKeyEventPlugin] on the key list). Disabled when `detailsAlwaysOn` is true or in screensaver (metadata always on).
 - `MediaRemoteControlsKeyEventPlugin`: Remote FF/RW tap-vs-hold seek, photo play/pause slideshow, opt-in D-pad seek, Back exits slideshow without pausing.
 - `FavoriteButtonControllerPlugin`: Adds a toggle for favoriting assets.
 - `ExternalPlayerButtonControllerPlugin`: Adds a button to open videos in an external player.

--- a/mediaslider/mediaslider/PLUGIN_SYSTEM.md
+++ b/mediaslider/mediaslider/PLUGIN_SYSTEM.md
@@ -114,6 +114,7 @@ MediaSliderConfiguration(
 
 - `MetadataViewPlugin`: Renders asset metadata (description, date, etc.).
 - `DateOverlayViewPlugin`: Optional top-of-screen DATE overlay with a dark scrim (`MediaSliderConfiguration.showDateTopLeft`). Bottom DATE metadata is unchanged.
+- `DetailsOverlayKeyPlugin`: Viewer Enter/Back for bottom details (register before [MediaRemoteControlsKeyEventPlugin] on the key list). Screensaver keeps metadata always on.
 - `MediaRemoteControlsKeyEventPlugin`: Remote FF/RW tap-vs-hold seek, photo play/pause slideshow, opt-in D-pad seek, Back exits slideshow without pausing.
 - `FavoriteButtonControllerPlugin`: Adds a toggle for favoriting assets.
 - `ExternalPlayerButtonControllerPlugin`: Adds a button to open videos in an external player.

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/config/MediaSliderConfiguration.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/config/MediaSliderConfiguration.kt
@@ -31,6 +31,11 @@ class MediaSliderConfiguration(
     val dpadSeeksInVideo: Boolean = false,
     /** When true, [nl.giejay.mediaslider.plugin.DateOverlayViewPlugin] shows DATE at the top. */
     val showDateTopLeft: Boolean = false,
+    /**
+     * When true in the viewer, bottom metadata stays always visible (no Enter/Back toggle).
+     * Screensaver ignores this and always shows metadata.
+     */
+    val detailsAlwaysOn: Boolean = false,
     var controllerPlugins: List<SliderControllerPlugin> = emptyList(),
     var viewPlugins: List<SliderViewPlugin<*>> = emptyList(),
     var keyEventPlugins: List<SliderKeyEventPlugin> = emptyList()

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/plugin/DetailsOverlayKeyPlugin.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/plugin/DetailsOverlayKeyPlugin.kt
@@ -1,0 +1,44 @@
+package nl.giejay.mediaslider.plugin
+
+import android.view.KeyEvent
+
+/**
+ * Viewer Enter/Back for the bottom details strip owned by [MetadataViewPlugin].
+ *
+ * - Enter/Center: show details (falls through so transport can still open).
+ * - Back: hide details when transport is already closed; otherwise let main/remote handle Back.
+ *
+ * Register on the key-plugin list **before** [MediaRemoteControlsKeyEventPlugin] so Back can
+ * dismiss details before exiting an autoplay slideshow.
+ */
+class DetailsOverlayKeyPlugin(
+    private val metadata: MetadataViewPlugin
+) : SliderKeyEventPlugin {
+
+    override fun onKeyDown(event: KeyEvent, state: SliderKeyEventState): SliderKeyEventResult {
+        if (!metadata.detailsToggleEnabled) {
+            return SliderKeyEventResult.UNHANDLED
+        }
+        val controller = state.controller
+        when (event.keyCode) {
+            KeyEvent.KEYCODE_DPAD_CENTER, KeyEvent.KEYCODE_ENTER -> {
+                if (controller.isControllerVisible) {
+                    return SliderKeyEventResult.DISPATCH_TO_SUPER
+                }
+                metadata.setDetailsVisible(true)
+                // Let MediaSliderController open the transport bar as well.
+                return SliderKeyEventResult.UNHANDLED
+            }
+            KeyEvent.KEYCODE_BACK -> {
+                if (controller.isControllerVisible) {
+                    return SliderKeyEventResult.UNHANDLED
+                }
+                if (metadata.detailsVisible) {
+                    metadata.setDetailsVisible(false)
+                    return SliderKeyEventResult.HANDLED_CONSUME
+                }
+            }
+        }
+        return SliderKeyEventResult.UNHANDLED
+    }
+}

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/plugin/MetadataViewPlugin.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/plugin/MetadataViewPlugin.kt
@@ -1,11 +1,11 @@
 package nl.giejay.mediaslider.plugin
 
+import android.os.Handler
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.ListView
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.zeuskartik.mediaslider.R
-import android.os.Handler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -17,11 +17,32 @@ import nl.giejay.mediaslider.config.MediaSliderConfiguration
 import nl.giejay.mediaslider.model.SliderItem
 import nl.giejay.mediaslider.model.SliderItemType
 import nl.giejay.mediaslider.model.SliderItemViewHolder
+import nl.giejay.mediaslider.util.MediaSliderListener
 import nl.giejay.mediaslider.view.MediaSliderController
 
+/**
+ * Bottom metadata lists (description, city, DATE rows, etc.).
+ * Viewer details visibility is driven by [DetailsOverlayKeyPlugin] via [setDetailsVisible].
+ * Screensaver ([MediaSliderListener]) keeps metadata always on.
+ */
 class MetadataViewPlugin : SliderViewPlugin<MetadataRenderState>, SliderControllerPlugin {
+    private var pluginLayer: ConstraintLayout? = null
+    private var lastConfig: MediaSliderConfiguration? = null
+    private var controllerVisible: Boolean = false
+
+    /** Viewer: Enter/Back toggle. Screensaver: always show. */
+    var detailsToggleEnabled: Boolean = false
+        private set
+    var detailsVisible: Boolean = true
+        private set
+    private var hasBottomDetails: Boolean = false
 
     override fun createState(context: SliderViewPluginContext, config: MediaSliderConfiguration): MetadataRenderState {
+        detailsToggleEnabled = context.context !is MediaSliderListener
+        detailsVisible = !detailsToggleEnabled
+        hasBottomDetails = config.metaDataConfig.isNotEmpty()
+        lastConfig = config
+
         val rightAdapter = MetaDataAdapter(
             context.context,
             config.metaDataConfig.filter { it.align == AlignOption.RIGHT },
@@ -47,9 +68,10 @@ class MetadataViewPlugin : SliderViewPlugin<MetadataRenderState>, SliderControll
     }
 
     override fun attachView(rootView: ConstraintLayout, state: MetadataRenderState?) {
+        pluginLayer = rootView
         val view = View.inflate(rootView.context, R.layout.metadata_holder, null)
         val params = ConstraintLayout.LayoutParams(
-            ConstraintLayout.LayoutParams.WRAP_CONTENT,
+            ConstraintLayout.LayoutParams.MATCH_CONSTRAINT,
             ConstraintLayout.LayoutParams.WRAP_CONTENT
         ).apply {
             startToStart = ConstraintLayout.LayoutParams.PARENT_ID
@@ -64,6 +86,8 @@ class MetadataViewPlugin : SliderViewPlugin<MetadataRenderState>, SliderControll
         config: MediaSliderConfiguration,
         state: MetadataRenderState?
     ) {
+        lastConfig = config
+        hasBottomDetails = config.metaDataConfig.isNotEmpty()
         val pluginState = state ?: return
         val listViewRight = context.rootView.findViewById<ListView>(R.id.metadata_view_right) ?: return
         listViewRight.divider = null
@@ -72,6 +96,7 @@ class MetadataViewPlugin : SliderViewPlugin<MetadataRenderState>, SliderControll
         val listViewLeft = context.rootView.findViewById<ListView>(R.id.metadata_view_left) ?: return
         listViewLeft.divider = null
         listViewLeft.adapter = pluginState.leftAdapter
+        applyDetailsChrome()
     }
 
     override fun onPageSettled(
@@ -82,44 +107,83 @@ class MetadataViewPlugin : SliderViewPlugin<MetadataRenderState>, SliderControll
         handler: Handler,
         state: MetadataRenderState?
     ) {
+        lastConfig = config
         val currentState = state ?: return
-        val leftAdapter = currentState.leftAdapter
-        val rightAdapter = currentState.rightAdapter
-
-        // Disable the gradient overlay for video items if the config specifies it should be hidden
-        val metaDataHolderView = context.rootView.findViewById<LinearLayout>(R.id.meta_data_holder)
-        if (sliderItem.type == SliderItemType.VIDEO) {
-            if (config.isGradiantOverlayVisible) {
-                metaDataHolderView?.background = null
-            }
-        } else {
-            if (config.isGradiantOverlayVisible) {
-                metaDataHolderView?.setBackgroundResource(R.drawable.gradient_overlay)
-            }
-        }
-
-        updateMetaData(context, leftAdapter, sliderItem.mainItem, sliderItemIndex, config)
+        updateMetaData(context, currentState.leftAdapter, sliderItem.mainItem, sliderItemIndex, config)
         updateMetaData(
             context,
-            rightAdapter,
+            currentState.rightAdapter,
             if (sliderItem.hasSecondaryItem()) sliderItem.secondaryItem!! else sliderItem.mainItem,
             sliderItemIndex,
             config
         )
+        // Video gradient handling only for always-on (screensaver) metadata.
+        if (!detailsToggleEnabled) {
+            val metaDataHolderView = context.rootView.findViewById<LinearLayout>(R.id.meta_data_holder)
+            if (sliderItem.type == SliderItemType.VIDEO) {
+                if (config.isGradiantOverlayVisible) {
+                    metaDataHolderView?.background = null
+                }
+            } else if (config.isGradiantOverlayVisible) {
+                metaDataHolderView?.setBackgroundResource(R.drawable.gradient_overlay)
+            }
+        } else {
+            applyDetailsChrome()
+        }
     }
 
-    override fun onControllerVisibilityChanged(isVisible: Boolean, rootView: View, controller: MediaSliderController, config: MediaSliderConfiguration) {
-        if(isVisible && config.isGradiantOverlayVisible) {
-            rootView.findViewById<LinearLayout>(R.id.meta_data_holder)?.background = null
-        } else if(!isVisible && config.isGradiantOverlayVisible) {
-            rootView.findViewById<LinearLayout>(R.id.meta_data_holder)?.setBackgroundResource(R.drawable.gradient_overlay)
+    override fun onControllerVisibilityChanged(
+        isVisible: Boolean,
+        rootView: View,
+        controller: MediaSliderController,
+        config: MediaSliderConfiguration
+    ) {
+        controllerVisible = isVisible
+        lastConfig = config
+        if (!detailsToggleEnabled) {
+            if (isVisible && config.isGradiantOverlayVisible) {
+                rootView.findViewById<LinearLayout>(R.id.meta_data_holder)?.background = null
+            } else if (!isVisible && config.isGradiantOverlayVisible) {
+                rootView.findViewById<LinearLayout>(R.id.meta_data_holder)
+                    ?.setBackgroundResource(R.drawable.gradient_overlay)
+            }
+            return
         }
+        if (isVisible) {
+            detailsVisible = true
+        }
+        applyDetailsChrome()
     }
 
     override fun onPageSelected(context: SliderViewPluginContext, sliderItemIndex: Int, state: MetadataRenderState?) {
         val currentState = state ?: return
         currentState.leftAdapter.notifyDataSetChanged()
         currentState.rightAdapter.notifyDataSetChanged()
+    }
+
+    /** Called by [DetailsOverlayKeyPlugin] for Enter/Back. */
+    fun setDetailsVisible(visible: Boolean) {
+        detailsVisible = visible
+        applyDetailsChrome()
+    }
+
+    private fun applyDetailsChrome() {
+        val holder = pluginLayer?.findViewById<LinearLayout>(R.id.meta_data_holder) ?: return
+        val detailsOn = !detailsToggleEnabled || detailsVisible
+        val show = detailsOn && hasBottomDetails
+        holder.visibility = if (show) View.VISIBLE else View.GONE
+        if (!show) return
+
+        val config = lastConfig
+        if (!detailsToggleEnabled) {
+            if (config?.isGradiantOverlayVisible == true && !controllerVisible) {
+                holder.setBackgroundResource(R.drawable.gradient_overlay)
+            } else if (config?.isGradiantOverlayVisible == true && controllerVisible) {
+                holder.background = null
+            }
+        } else {
+            holder.setBackgroundResource(R.drawable.metadata_details_scrim)
+        }
     }
 
     private fun updateMetaData(
@@ -143,5 +207,3 @@ class MetadataViewPlugin : SliderViewPlugin<MetadataRenderState>, SliderControll
         }
     }
 }
-
-

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/plugin/MetadataViewPlugin.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/plugin/MetadataViewPlugin.kt
@@ -1,11 +1,11 @@
 package nl.giejay.mediaslider.plugin
 
-import android.os.Handler
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.ListView
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.zeuskartik.mediaslider.R
+import android.os.Handler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/plugin/MetadataViewPlugin.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/plugin/MetadataViewPlugin.kt
@@ -38,7 +38,7 @@ class MetadataViewPlugin : SliderViewPlugin<MetadataRenderState>, SliderControll
     private var hasBottomDetails: Boolean = false
 
     override fun createState(context: SliderViewPluginContext, config: MediaSliderConfiguration): MetadataRenderState {
-        detailsToggleEnabled = context.context !is MediaSliderListener
+        detailsToggleEnabled = context.context !is MediaSliderListener && !config.detailsAlwaysOn
         detailsVisible = !detailsToggleEnabled
         hasBottomDetails = config.metaDataConfig.isNotEmpty()
         lastConfig = config
@@ -88,6 +88,10 @@ class MetadataViewPlugin : SliderViewPlugin<MetadataRenderState>, SliderControll
     ) {
         lastConfig = config
         hasBottomDetails = config.metaDataConfig.isNotEmpty()
+        detailsToggleEnabled = context.context !is MediaSliderListener && !config.detailsAlwaysOn
+        if (!detailsToggleEnabled) {
+            detailsVisible = true
+        }
         val pluginState = state ?: return
         val listViewRight = context.rootView.findViewById<ListView>(R.id.metadata_view_right) ?: return
         listViewRight.divider = null

--- a/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/view/WrapContentListView.kt
+++ b/mediaslider/mediaslider/src/main/kotlin/nl/giejay/mediaslider/view/WrapContentListView.kt
@@ -1,0 +1,22 @@
+package nl.giejay.mediaslider.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.ListView
+
+/**
+ * [ListView] that expands to its children when height is [android.view.ViewGroup.LayoutParams.WRAP_CONTENT].
+ * Needed for the non-scrolling EXIF columns in the slider details overlay.
+ */
+class WrapContentListView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ListView(context, attrs, defStyleAttr) {
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val expandedHeight = MeasureSpec.makeMeasureSpec(Integer.MAX_VALUE shr 2, MeasureSpec.AT_MOST)
+        super.onMeasure(widthMeasureSpec, expandedHeight)
+        layoutParams.height = measuredHeight
+    }
+}

--- a/mediaslider/mediaslider/src/main/res/drawable/metadata_details_scrim.xml
+++ b/mediaslider/mediaslider/src/main/res/drawable/metadata_details_scrim.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="90"
+        android:startColor="#C0000000"
+        android:endColor="#00000000"
+        android:type="linear" />
+</shape>

--- a/mediaslider/mediaslider/src/main/res/layout/metadata_holder.xml
+++ b/mediaslider/mediaslider/src/main/res/layout/metadata_holder.xml
@@ -1,24 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/meta_data_holder"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@drawable/metadata_details_scrim"
     android:baselineAligned="false"
     android:elevation="10dp"
-    android:gravity="bottom|left"
-    android:paddingBottom="30dp">
+    android:gravity="bottom"
+    android:orientation="horizontal"
+    android:paddingBottom="30dp"
+    android:visibility="gone">
 
-    <ListView
+    <nl.giejay.mediaslider.view.WrapContentListView
         android:id="@+id/metadata_view_left"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        android:divider="@null"
+        android:dividerHeight="0dp"
+        android:focusable="false"
+        android:focusableInTouchMode="false"
+        android:scrollbars="none" />
 
-    <ListView
+    <nl.giejay.mediaslider.view.WrapContentListView
         android:id="@+id/metadata_view_right"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1" />
-
+        android:layout_weight="1"
+        android:divider="@null"
+        android:dividerHeight="0dp"
+        android:focusable="false"
+        android:focusableInTouchMode="false"
+        android:scrollbars="none" />
 </LinearLayout>
-


### PR DESCRIPTION
## Summary
- Add `DetailsOverlayKeyPlugin` so viewer Enter shows bottom metadata (media controls still open) and Back dismisses details after media controls are closed
- Update `metadata_holder` with details scrim + `WrapContentListView`; holder starts hidden in the viewer
- Add **Always show details** setting (default off) to keep bottom metadata always visible and skip the Enter/Back toggle
- Keep screensaver metadata always on; register the details key plugin before remote so Back can clear details before exiting slideshow

## Test plan
- [ ] Viewer (default): open a photo — bottom metadata is hidden initially
- [ ] Enter — bottom metadata and media controls appear
- [ ] Back once — media controls hide; metadata remains
- [ ] Back again — bottom metadata hides
- [ ] Enable **Always show details** — metadata stays visible; Enter/Back no longer toggle details
- [ ] Screensaver — metadata stays always visible; Enter does not use this toggle
- [ ] With slideshow playing — Back dismisses details before exiting slideshow