### PR TITLE
Fix fragile appContext initialization ordering

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,14 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
+        <!-- Runs before Application.onCreate() and before any other provider with a lower
+             initOrder (FirebaseInitProvider is at 100, this is set higher so it always wins). -->
+        <provider
+            android:name="nl.giejay.android.tv.immich.AppContextInitializer"
+            android:authorities="${applicationId}.appcontextinitializer"
+            android:exported="false"
+            android:initOrder="2147483647" />
+
         <service
             android:name="nl.giejay.android.tv.immich.screensaver.ScreenSaverService"
             android:exported="true"

--- a/app/src/main/java/nl/giejay/android/tv/immich/AppContextInitializer.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/AppContextInitializer.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.giejay.android.tv.immich
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+
+// Runs before Application.onCreate() and before any other provider with a lower initOrder
+// (FirebaseInitProvider is at 100, this is set higher in the manifest so it always wins).
+class AppContextInitializer : ContentProvider() {
+
+    override fun onCreate(): Boolean {
+        ImmichApplication.appContext = context
+        return true
+    }
+
+    override fun query(
+        uri: Uri, projection: Array<out String>?, selection: String?,
+        selectionArgs: Array<out String>?, sortOrder: String?
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+    override fun update(
+        uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String>?
+    ): Int = 0
+}

--- a/app/src/main/java/nl/giejay/android/tv/immich/ImmichApplication.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/ImmichApplication.kt
@@ -38,6 +38,8 @@ class ImmichApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        // AppContextInitializer (initOrder set higher than Firebase's) sets this first;
+        // kept as a cheap no-op for direct Application construction.
         appContext = this
         PreferenceManager.init(this)
 


### PR DESCRIPTION
- App-wide context was only safe because of the exact order two lines happened to run in `onCreate()` - a future refactor could silently break that and crash the app on launch.
- Now set via an Android provider that's guaranteed to run first, so it no longer depends on line order. ([reference](https://developer.android.com/topic/libraries/app-startup) - this is the same mechanism Android's own startup library uses for this exact problem)
- No other behavior changes.