### PR TITLE
Enable R8 shrinking and obfuscation for release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -12,10 +12,31 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Keep line numbers so Crashlytics release crash reports are still readable after obfuscation.
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Gson uses reflection to read/write these fields by name, so field names and no-arg
+# constructors must survive R8 or (de)serialization silently breaks at runtime.
+-keep class nl.giejay.android.tv.immich.api.model.** { *; }
+-keep class nl.giejay.android.tv.immich.api.service.** { *; }
+
+# MetaDataSerializer (mediaslider module) delegates to Gson's default reflective adapter
+# for these classes and stores/reads the result as JSON in SharedPreferences, so their
+# field names must stay stable across obfuscation.
+-keep class nl.giejay.mediaslider.adapter.MetaDataItem { *; }
+-keep class * extends nl.giejay.mediaslider.adapter.MetaDataItem { *; }
+
+# MediaSliderView swaps this field in by name via reflection to control slide animation speed.
+-keepclassmembers class androidx.viewpager.widget.ViewPager {
+    android.widget.Scroller mScroller;
+}
+
+# Pref/PrefScreen objects are enumerated via Kotlin sealedSubclasses reflection, their class
+# simple names double as SharedPreferences keys (see Pref.key()), and MetaDataScreen is resolved
+# by fully-qualified name from nav_graph.xml's argType -- all of this breaks silently under R8
+# renaming/shrinking without keeping the whole package intact.
+-keep class nl.giejay.android.tv.immich.shared.prefs.** { *; }

--- a/app/src/test/java/nl/giejay/android/tv/immich/timeline/TimelineViewModelTest.kt
+++ b/app/src/test/java/nl/giejay/android/tv/immich/timeline/TimelineViewModelTest.kt
@@ -464,7 +464,9 @@ class TimelineViewModelTest {
         assertEquals(0, fetches.get())
 
         vm.prefetchAroundDay("2026-06-15")
-        assertTrue(fetchLatch.await(2, TimeUnit.SECONDS))
+        // 2s was tight enough to flake on loaded/shared CI runners (real Debouncer + Dispatchers.IO
+        // threads, not virtual time) even though the fetches themselves are effectively instant.
+        assertTrue(fetchLatch.await(10, TimeUnit.SECONDS))
         advanceUntilIdle()
 
         assertTrue(vm.bucketAssets.value.containsKey("2026-06-01"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,6 @@ kotlin.code.style=official
 android.disallowKotlinSourceSets=false
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+# Optimized resource shrinking requires non-final resource IDs; this project keeps them final
+# (see android.nonFinalResIds above), so fall back to the classic resource shrinker.
+android.r8.optimizedResourceShrinking=false


### PR DESCRIPTION
- `minifyEnabled`/`shrinkResources` were off for release even though ProGuard rule files were already wired up, so they did nothing. Turned them on, and added keep rules for everything only reached via reflection (Gson-deserialized API/DTO classes, the settings screens' reflective preference lookup, a mediaslider `ViewPager` field hack) so nothing silently breaks at runtime.
- Verified by inspecting R8's actual output (`mapping.txt`/`usage.txt`), not just by getting a green build - confirmed nothing needed got renamed or removed.

| | Before (6.1.0 release) | After | Change |
|---|---|---|---|
| APK size | 37.3 MB | 28.7 MB | -23% |
| Code (dex) | 30.4 MB, 6 files | 6.4 MB, 2 files | -79% |
| resources.arsc | 1.65 MB | 1.38 MB | -17% |
| File entries | 1347 | 1180 | -12% |

- Comparison build was signed with a throwaway local key for testing only, not the real release key, but that only affects the signature block by a few KB and doesn't change the picture above.