### PR TITLE
Add Android TV home screen channels

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,7 +107,7 @@ dependencies {
 //    implementation "androidx.work:work-runtime:$work_version"
 
     // TV provider library used for updating home screen channels
-//    implementation 'androidx.tvprovider:tvprovider:1.0.0'
+    implementation libs.androidx.tvprovider
 
     implementation libs.rxandroid
     implementation libs.rxjava

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:configChanges="keyboard|keyboardHidden|navigation">
 
             <!-- Used as the main entry point from the leanback launcher -->
@@ -86,17 +87,29 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
+            <!-- Deep links from home screen channel programs/channels, see homescreenchannels.ChannelDeepLinks -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="immichtv" />
+            </intent-filter>
+
         </activity>
 
         <!-- BroadcastReceiver for setting up the home screen channel -->
-<!--        <receiver-->
-<!--            android:name="nl.giejay.android.tv.immich.homescreenchannels.HomeScreenChannelReceiver"-->
-<!--            android:exported="true">-->
-<!--            <intent-filter>-->
-<!--                <action android:name="android.media.tv.action.INITIALIZE_PROGRAMS" />-->
-<!--                <category android:name="android.intent.category.DEFAULT" />-->
-<!--            </intent-filter>-->
-<!--        </receiver>-->
+        <receiver
+            android:name="nl.giejay.android.tv.immich.homescreenchannels.HomeScreenChannelReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.media.tv.action.INITIALIZE_PROGRAMS" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.media.tv.action.PREVIEW_PROGRAM_BROWSABLE_DISABLED" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </receiver>
 
         <!--
          ~ Options provider class for Cast Connect when CastReceiverContext

--- a/app/src/main/java/nl/giejay/android/tv/immich/ImmichApplication.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/ImmichApplication.kt
@@ -18,11 +18,11 @@ package nl.giejay.android.tv.immich
 import android.app.Application
 import android.content.Context
 import android.util.Log
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import nl.giejay.android.tv.immich.homescreenchannels.HomeScreenChannelManager
 import nl.giejay.android.tv.immich.shared.prefs.DEBUG_MODE
 import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
 import nl.giejay.android.tv.immich.shared.prefs.USER_ID
@@ -53,6 +53,13 @@ class ImmichApplication : Application() {
             PreferenceManager.save(USER_ID, userId)
         }
         FirebaseCrashlytics.getInstance().setUserId(userId)
+
+        HomeScreenChannelManager.initSubscriptions()
+        ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+                HomeScreenChannelManager.scheduleRefresh("app_foreground")
+            }
+        })
     }
 
     companion object {

--- a/app/src/main/java/nl/giejay/android/tv/immich/MainActivity.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/MainActivity.kt
@@ -1,17 +1,47 @@
 package nl.giejay.android.tv.immich
 
+import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.KeyEvent
+import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph
 import androidx.navigation.fragment.NavHostFragment
+import arrow.core.getOrElse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import nl.giejay.android.tv.immich.api.ApiClient
+import nl.giejay.android.tv.immich.api.ApiClientConfig
+import nl.giejay.android.tv.immich.home.HomeFragmentDirections
+import nl.giejay.android.tv.immich.homescreenchannels.ChannelDeepLinks
+import nl.giejay.android.tv.immich.homescreenchannels.DeepLinkTarget
 import nl.giejay.android.tv.immich.shared.prefs.MetaDataScreen
 import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
+import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ANIMATE_ASSET_SLIDE
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ANIMATION_SPEED
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_DPAD_SEEK_IN_VIDEO
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_FORCE_ORIGINAL_VIDEO
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_GLIDE_TRANSFORMATION
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_INTERVAL
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_HEIGHT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_MAX_CUT_OFF_WIDTH
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ONLY_USE_THUMBNAILS
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_PAN_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_SHOW_DATE_TOP_LEFT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_EFFECT
+import nl.giejay.android.tv.immich.shared.prefs.SLIDER_ZOOM_SCROLL_PANORAMAS
+import nl.giejay.android.tv.immich.shared.util.toSliderItem
 import nl.giejay.android.tv.immich.shared.viewmodel.KeyEventsViewModel
+import nl.giejay.android.tv.immich.slider.ImmichMediaSliderArgs
 import nl.giejay.mediaslider.adapter.AlignOption
+import nl.giejay.mediaslider.config.MediaSliderConfiguration
+import nl.giejay.mediaslider.model.SliderItemViewHolder
+import nl.giejay.mediaslider.viewmodel.MediaSliderViewModel
 import timber.log.Timber
 
 
@@ -45,6 +75,20 @@ class MainActivity : FragmentActivity() {
             PreferenceManager.saveMetaData(AlignOption.RIGHT, MetaDataScreen.SCREENSAVER, screenSaverMetaDataFromOldPrefs)
         }
 
+        // guarded so a process-restore recreation (savedInstanceState != null) doesn't
+        // re-fetch and re-push a deep-linked asset into the slider a second time
+        if (savedInstanceState == null) {
+            loadDeepLinkOrStartingPage(intent.data)
+        }
+    }
+
+    /**
+     * MainActivity is singleTask (see the manifest), so a channel/card tap while the app is
+     * already running arrives here instead of spinning up a second instance.
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
         loadDeepLinkOrStartingPage(intent.data)
     }
 
@@ -61,9 +105,68 @@ class MainActivity : FragmentActivity() {
     private fun loadDeepLinkOrStartingPage(
         uri: Uri?
     ) {
-        if (uri == null) {
+        // deep links from home screen channel programs/channels, see homescreenchannels.ChannelDeepLinks
+        val target = ChannelDeepLinks.parse(uri)
+        // resuming a deep link after signing in isn't supported yet - it just falls through to auth
+        if (target is DeepLinkTarget.None || !PreferenceManager.isLoggedId()) {
             loadStartingPage()
             return
+        }
+
+        navGraph.setStartDestination(R.id.homeFragment)
+        navController.graph = navGraph
+
+        when (target) {
+            is DeepLinkTarget.Asset -> openAssetFromDeepLink(target.assetId)
+            is DeepLinkTarget.Album -> navController.navigate(
+                HomeFragmentDirections.actionHomeFragmentToAlbumDetailsFragment(target.albumId, target.albumName)
+            )
+            DeepLinkTarget.Home, DeepLinkTarget.None -> Unit
+        }
+    }
+
+    private fun openAssetFromDeepLink(assetId: String) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            val apiClient = ApiClient.getClient(ApiClientConfig.fromPrefs())
+            val asset = apiClient.getAsset(assetId).getOrElse {
+                Timber.w("Could not load deep-linked asset $assetId: $it")
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(this@MainActivity, getString(R.string.no_items_to_play), Toast.LENGTH_SHORT).show()
+                }
+                return@launch
+            }
+            val config = MediaSliderConfiguration(
+                startPosition = 0,
+                interval = PreferenceManager.get(SLIDER_INTERVAL),
+                isOnlyUseThumbnails = PreferenceManager.get(SLIDER_ONLY_USE_THUMBNAILS),
+                isVideoSoundEnable = true,
+                items = listOf(SliderItemViewHolder(asset.toSliderItem())),
+                loadMore = null,
+                animationSpeedMillis = PreferenceManager.get(SLIDER_ANIMATION_SPEED),
+                maxCutOffHeight = PreferenceManager.get(SLIDER_MAX_CUT_OFF_HEIGHT),
+                maxCutOffWidth = PreferenceManager.get(SLIDER_MAX_CUT_OFF_WIDTH),
+                glideTransformation = PreferenceManager.get(SLIDER_GLIDE_TRANSFORMATION),
+                gradiantOverlay = false,
+                enableSlideAnimation = PreferenceManager.get(SCREENSAVER_ANIMATE_ASSET_SLIDE),
+                metaDataConfig = PreferenceManager.getAllMetaData(MetaDataScreen.VIEWER),
+                zoomAndScrollPanorama = PreferenceManager.get(SLIDER_ZOOM_SCROLL_PANORAMAS),
+                zoomEffectPercent = PreferenceManager.get(SLIDER_ZOOM_EFFECT),
+                panEffectPercent = PreferenceManager.get(SLIDER_PAN_EFFECT),
+                useLargeVideoBuffer = PreferenceManager.get(SLIDER_FORCE_ORIGINAL_VIDEO),
+                dpadSeeksInVideo = PreferenceManager.get(SLIDER_DPAD_SEEK_IN_VIDEO),
+                showDateTopLeft = PreferenceManager.get(SLIDER_SHOW_DATE_TOP_LEFT)
+            )
+            withContext(Dispatchers.Main) {
+                ViewModelProvider(this@MainActivity)[MediaSliderViewModel::class.java].configuration = config
+                try {
+                    // the global action (not the homeFragment-scoped one) since the current
+                    // destination may have moved on during the network round-trip above
+                    navController.navigate(R.id.action_to_photo_slider, ImmichMediaSliderArgs(timelineView = false).toBundle())
+                } catch (e: IllegalArgumentException) {
+                    Timber.w(e, "Could not navigate to the photo slider for deep-linked asset $assetId")
+                    Toast.makeText(this@MainActivity, getString(R.string.no_items_to_play), Toast.LENGTH_SHORT).show()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/nl/giejay/android/tv/immich/album/AlbumFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/album/AlbumFragment.kt
@@ -2,15 +2,19 @@ package nl.giejay.android.tv.immich.album
 
 import android.os.Bundle
 import android.view.View
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import arrow.core.Either
+import kotlinx.coroutines.launch
 import nl.giejay.android.tv.immich.api.ApiClient
 import nl.giejay.android.tv.immich.api.model.Album
 import nl.giejay.android.tv.immich.api.util.ApiUtil
 import nl.giejay.android.tv.immich.card.Card
 import nl.giejay.android.tv.immich.home.HomeFragmentDirections
+import nl.giejay.android.tv.immich.homescreenchannels.HomeScreenChannelManager
 import nl.giejay.android.tv.immich.shared.fragment.VerticalCardGridFragment
 import nl.giejay.android.tv.immich.shared.prefs.ALBUMS_SORTING
+import nl.giejay.android.tv.immich.shared.prefs.CHANNEL_ALBUMS
 import nl.giejay.android.tv.immich.shared.prefs.EXCLUDE_ASSETS_IN_ALBUM
 import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ALBUMS
@@ -21,6 +25,7 @@ import timber.log.Timber
 enum class SelectionType {
     SET_SCREENSAVER,
     EXCLUDED_ALBUMS,
+    SET_CHANNEL_ALBUMS,
 }
 
 class AlbumFragment : VerticalCardGridFragment<Album>() {
@@ -37,6 +42,10 @@ class AlbumFragment : VerticalCardGridFragment<Album>() {
 
             SelectionType.EXCLUDED_ALBUMS -> {
                 EXCLUDE_ASSETS_IN_ALBUM
+            }
+
+            SelectionType.SET_CHANNEL_ALBUMS -> {
+                CHANNEL_ALBUMS
             }
         }
         PreferenceManager.subscribe(ALBUMS_SORTING) {
@@ -76,8 +85,20 @@ class AlbumFragment : VerticalCardGridFragment<Album>() {
         val currentAlbums = PreferenceManager.get(selectionTypeKey)
         if (card.selected) {
             PreferenceManager.save(selectionTypeKey, currentAlbums + card.id)
+            if (selectionType == SelectionType.SET_CHANNEL_ALBUMS) {
+                // creating the channel + requesting approval needs the Activity and must happen
+                // while the app is foregrounded, so it can't wait for the debounced background sync
+                lifecycleScope.launch {
+                    HomeScreenChannelManager.createAlbumChannelAndRequestApproval(requireActivity(), card.id, card.title)
+                }
+            }
         } else {
             PreferenceManager.save(selectionTypeKey, currentAlbums - card.id)
+            if (selectionType == SelectionType.SET_CHANNEL_ALBUMS) {
+                lifecycleScope.launch {
+                    HomeScreenChannelManager.deleteAlbumChannel(requireContext().applicationContext, card.id)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/nl/giejay/android/tv/immich/api/ApiClient.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/api/ApiClient.kt
@@ -19,7 +19,10 @@ import nl.giejay.android.tv.immich.api.model.TimelineAsset
 import nl.giejay.android.tv.immich.api.model.toTimelineAssets
 import nl.giejay.android.tv.immich.api.service.ApiService
 import nl.giejay.android.tv.immich.api.util.ApiUtil.executeAPICall
+import nl.giejay.android.tv.immich.shared.prefs.API_KEY
 import nl.giejay.android.tv.immich.shared.prefs.ContentType
+import nl.giejay.android.tv.immich.shared.prefs.DEBUG_MODE
+import nl.giejay.android.tv.immich.shared.prefs.DISABLE_SSL_VERIFICATION
 import nl.giejay.android.tv.immich.shared.prefs.EXCLUDE_ASSETS_IN_ALBUM
 import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
 import nl.giejay.android.tv.immich.shared.prefs.RECENT_ASSETS_MONTHS_BACK
@@ -41,7 +44,16 @@ data class ApiClientConfig(
     val apiKey: String,
     val disableSslVerification: Boolean,
     val debugMode: Boolean
-)
+) {
+    companion object {
+        fun fromPrefs(): ApiClientConfig = ApiClientConfig(
+            PreferenceManager.hostName,
+            PreferenceManager.get(API_KEY),
+            PreferenceManager.get(DISABLE_SSL_VERIFICATION),
+            PreferenceManager.get(DEBUG_MODE)
+        )
+    }
+}
 
 // internal so app/src/test can call it directly without instantiating ApiClient/Retrofit
 internal fun buildListAssetsSearchRequest(

--- a/app/src/main/java/nl/giejay/android/tv/immich/api/util/ApiUtil.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/api/util/ApiUtil.kt
@@ -14,9 +14,12 @@ import java.util.UUID
 
 object ApiUtil {
 
-    fun getThumbnailUrl(assetId: String?, format: String, loadEdited: Boolean = false): String? {
+    fun getThumbnailUrl(assetId: String?, format: String, loadEdited: Boolean = false, includeApiKey: Boolean = false): String? {
         return assetId?.let {
-            "${hostName().lowercase()}/api/assets/${it}/thumbnail?size=${format}&edited=${loadEdited}"
+            val base = "${hostName().lowercase()}/api/assets/${it}/thumbnail?size=${format}&edited=${loadEdited}"
+            // api key is added here for home screen channel poster art, since the launcher fetches it
+            // in its own process, without our OkHttp interceptor
+            if (includeApiKey) "${base}&apiKey=${PreferenceManager.get(API_KEY)}" else base
         }
     }
 

--- a/app/src/main/java/nl/giejay/android/tv/immich/homescreenchannels/ChannelDeepLinks.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/homescreenchannels/ChannelDeepLinks.kt
@@ -1,0 +1,40 @@
+package nl.giejay.android.tv.immich.homescreenchannels
+
+import android.net.Uri
+
+private const val SCHEME = "immichtv"
+
+sealed class DeepLinkTarget {
+    data class Asset(val assetId: String) : DeepLinkTarget()
+    data class Album(val albumId: String, val albumName: String) : DeepLinkTarget()
+    data object Home : DeepLinkTarget()
+    data object None : DeepLinkTarget()
+}
+
+object ChannelDeepLinks {
+
+    fun forAsset(assetId: String): Uri =
+        Uri.parse("$SCHEME://asset/$assetId")
+
+    fun forAlbum(albumId: String, albumName: String): Uri =
+        Uri.parse("$SCHEME://album/$albumId").buildUpon()
+            .appendQueryParameter("name", albumName)
+            .build()
+
+    fun forHome(): Uri = Uri.parse("$SCHEME://home")
+
+    fun parse(uri: Uri?): DeepLinkTarget {
+        if (uri == null || uri.scheme != SCHEME) {
+            return DeepLinkTarget.None
+        }
+        return when (uri.host) {
+            "asset" -> uri.lastPathSegment?.let { DeepLinkTarget.Asset(it) } ?: DeepLinkTarget.None
+            "album" -> uri.lastPathSegment?.let {
+                DeepLinkTarget.Album(it, uri.getQueryParameter("name") ?: "")
+            } ?: DeepLinkTarget.None
+
+            "home" -> DeepLinkTarget.Home
+            else -> DeepLinkTarget.None
+        }
+    }
+}

--- a/app/src/main/java/nl/giejay/android/tv/immich/homescreenchannels/ChannelRegistry.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/homescreenchannels/ChannelRegistry.kt
@@ -1,0 +1,57 @@
+package nl.giejay.android.tv.immich.homescreenchannels
+
+import com.google.gson.Gson
+import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
+import timber.log.Timber
+
+private const val PREF_KEY = "home_screen_channel_registry"
+private const val MAX_EXCLUDED_ASSET_IDS_PER_CHANNEL = 200
+
+/**
+ * Local bookkeeping the TvProvider doesn't give us for free: which asset ids the user explicitly
+ * removed a card for, per channel (keyed by that channel's internalProviderId - see
+ * [HomeScreenChannelManager]), so a later sync doesn't reinsert them, per the platform's
+ * ACTION_PREVIEW_PROGRAM_BROWSABLE_DISABLED contract. Channel identity itself is NOT tracked
+ * here - the TvProvider (queried by internalProviderId) is the single source of truth for that,
+ * so a killed process or a stale/restored registry can never orphan or duplicate a channel.
+ */
+data class ChannelRegistry(
+    // channel internalProviderId -> excluded asset ids, ordered oldest-first so eviction is a plain takeLast
+    val excludedAssetIdsByChannel: Map<String, List<String>> = emptyMap()
+)
+
+object ChannelRegistryStore {
+    private val gson = Gson()
+
+    @Synchronized
+    fun load(): ChannelRegistry {
+        val json = PreferenceManager.sharedPreference.getString(PREF_KEY, null) ?: return ChannelRegistry()
+        return try {
+            gson.fromJson(json, ChannelRegistry::class.java) ?: ChannelRegistry()
+        } catch (e: Exception) {
+            Timber.w(e, "Could not parse home screen channel registry, resetting it")
+            ChannelRegistry()
+        }
+    }
+
+    @Synchronized
+    private fun save(registry: ChannelRegistry) {
+        PreferenceManager.sharedPreference.edit().putString(PREF_KEY, gson.toJson(registry)).apply()
+    }
+
+    @Synchronized
+    private fun update(mutate: (ChannelRegistry) -> ChannelRegistry) {
+        save(mutate(load()))
+    }
+
+    fun excludedAssetIds(channelInternalId: String): List<String> =
+        load().excludedAssetIdsByChannel[channelInternalId] ?: emptyList()
+
+    fun addExcludedAssetId(channelInternalId: String, assetId: String) {
+        update { registry ->
+            val current = registry.excludedAssetIdsByChannel[channelInternalId] ?: emptyList()
+            val updated = (current + assetId).distinct().takeLast(MAX_EXCLUDED_ASSET_IDS_PER_CHANNEL)
+            registry.copy(excludedAssetIdsByChannel = registry.excludedAssetIdsByChannel + (channelInternalId to updated))
+        }
+    }
+}

--- a/app/src/main/java/nl/giejay/android/tv/immich/homescreenchannels/HomeScreenChannelManager.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/homescreenchannels/HomeScreenChannelManager.kt
@@ -1,0 +1,341 @@
+package nl.giejay.android.tv.immich.homescreenchannels
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.ContentUris
+import android.content.Context
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import android.widget.Toast
+import androidx.tvprovider.media.tv.Channel
+import androidx.tvprovider.media.tv.ChannelLogoUtils
+import androidx.tvprovider.media.tv.PreviewProgram
+import androidx.tvprovider.media.tv.TvContractCompat
+import arrow.core.getOrElse
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import nl.giejay.android.tv.immich.ImmichApplication
+import nl.giejay.android.tv.immich.R
+import nl.giejay.android.tv.immich.api.ApiClient
+import nl.giejay.android.tv.immich.api.ApiClientConfig
+import nl.giejay.android.tv.immich.api.model.Asset
+import nl.giejay.android.tv.immich.api.util.ApiUtil
+import nl.giejay.android.tv.immich.shared.prefs.CHANNEL_ALBUMS
+import nl.giejay.android.tv.immich.shared.prefs.ContentType
+import nl.giejay.android.tv.immich.shared.prefs.ENABLE_HOME_SCREEN_CHANNELS
+import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
+import nl.giejay.android.tv.immich.shared.util.Debouncer
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+
+private const val MAX_PROGRAMS_PER_CHANNEL = 15
+private const val DEBOUNCE_KEY = "home_screen_channels_sync"
+private const val REQUEST_CHANNEL_BROWSABLE = 4201
+private const val DEFAULT_CHANNEL_INTERNAL_ID = "default"
+private const val ALBUM_CHANNEL_INTERNAL_ID_PREFIX = "album:"
+
+private fun albumChannelInternalId(albumId: String) = "$ALBUM_CHANNEL_INTERNAL_ID_PREFIX$albumId"
+private fun albumIdFromChannelInternalId(internalId: String) = internalId.removePrefix(ALBUM_CHANNEL_INTERNAL_ID_PREFIX)
+
+/**
+ * Publishes Immich content as Android TV home screen channels: one default "Recent photos"
+ * channel, plus one channel per album the user picks in settings. A channel is a
+ * [Channel]/row, a program is one asset/card - see
+ * https://developer.android.com/training/tv/discovery/recommendations-channel, which requires a
+ * program to be a single piece of content, so albums map to channels rather than to cards.
+ *
+ * The TvProvider itself (queried by the internalProviderId set at creation, [DEFAULT_CHANNEL_INTERNAL_ID]
+ * / [albumChannelInternalId]) is the single source of truth for which channels exist - nothing here
+ * trusts a locally-cached channel id, so a process kill between an insert and a would-be local
+ * write can never orphan or duplicate a channel. [mutex] serializes every entry point so two
+ * triggers (foreground, pref change, "Refresh now", the install receiver) can never race each
+ * other into a duplicate create or a lost delete.
+ */
+object HomeScreenChannelManager {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val mutex = Mutex()
+    private var subscribed = false
+
+    /** Wires pref-change triggers. Idempotent, call once from [ImmichApplication.onCreate]. */
+    @Synchronized
+    fun initSubscriptions() {
+        if (subscribed) return
+        subscribed = true
+        PreferenceManager.subscribeMultiple(listOf(CHANNEL_ALBUMS, ENABLE_HOME_SCREEN_CHANNELS)) {
+            scheduleRefresh("prefs_changed")
+        }
+    }
+
+    /** Debounced background sync, safe to call from any thread/trigger. */
+    fun scheduleRefresh(reason: String) {
+        Debouncer.debounce(DEBOUNCE_KEY, Runnable {
+            scope.launch {
+                Timber.d("Syncing home screen channels ($reason)")
+                syncAll(ImmichApplication.appContext!!)
+            }
+        }, 5, TimeUnit.SECONDS)
+    }
+
+    /**
+     * Creates/updates/deletes every channel this app owns so they match current login state,
+     * the enable toggle, and the selected albums. Safe to call concurrently - callers are
+     * serialized on [mutex].
+     */
+    suspend fun syncAll(context: Context) = mutex.withLock {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return@withLock
+        }
+        if (!PreferenceManager.isLoggedId() || !PreferenceManager.get(ENABLE_HOME_SCREEN_CHANNELS)) {
+            try {
+                deleteAllChannels(context)
+            } catch (e: Exception) {
+                Timber.e(e, "Could not delete home screen channels")
+            }
+            return@withLock
+        }
+        try {
+            syncDefaultChannel(context)
+            syncAlbumChannels(context)
+        } catch (e: Exception) {
+            Timber.e(e, "Could not sync home screen channels")
+        }
+    }
+
+    /**
+     * Creates (if the TvProvider doesn't already have one for [albumId]) and requests approval
+     * for one album's channel. Called from the foreground album picker rather than the debounced
+     * background sync, since approval requires an [Activity] and must happen while the app is in
+     * the foreground (platform requirement). The background sync only ever syncs *programs* for
+     * an album channel that already exists - it never creates one, so it can never leave behind
+     * a channel nobody was ever asked to approve.
+     */
+    suspend fun createAlbumChannelAndRequestApproval(activity: Activity, albumId: String, albumName: String) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        try {
+            val channelId = mutex.withLock {
+                withContext(Dispatchers.IO) {
+                    val internalId = albumChannelInternalId(albumId)
+                    findChannel(activity, internalId)?.id
+                        ?: createChannel(activity, internalId, albumName, ChannelDeepLinks.forAlbum(albumId, albumName), requestBrowsable = false)
+                }
+            }
+            requestChannelApproval(activity, channelId)
+        } catch (e: Exception) {
+            Timber.e(e, "Could not create/approve home screen channel for album $albumId")
+            Toast.makeText(activity, activity.getString(R.string.home_screen_channel_error), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    suspend fun deleteAlbumChannel(context: Context, albumId: String) {
+        try {
+            mutex.withLock {
+                withContext(Dispatchers.IO) {
+                    findChannel(context, albumChannelInternalId(albumId))?.let { deleteChannel(context, it.id) }
+                }
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Could not delete home screen channel for album $albumId")
+        }
+    }
+
+    private suspend fun syncDefaultChannel(context: Context) {
+        val apiClient = ApiClient.getClient(ApiClientConfig.fromPrefs())
+        // order=desc, not random - a stable order keeps this channel's card order from
+        // churning (insert+delete) on every refresh
+        val assets = apiClient.listAssets(
+            page = 1,
+            pageCount = MAX_PROGRAMS_PER_CHANNEL,
+            random = false,
+            order = "desc",
+            contentType = ContentType.ALL
+        ).fold({
+            Timber.w("Could not load recent assets for the default home screen channel: $it")
+            null
+        }, { it.assets }) ?: return
+
+        val channelId = findChannel(context, DEFAULT_CHANNEL_INTERNAL_ID)?.id
+            ?: createChannel(
+                context,
+                internalProviderId = DEFAULT_CHANNEL_INTERNAL_ID,
+                displayName = context.getString(R.string.channel_recent_photos),
+                appLinkUri = ChannelDeepLinks.forHome(),
+                requestBrowsable = true
+            )
+
+        syncProgramsForChannel(context, DEFAULT_CHANNEL_INTERNAL_ID, channelId, assets)
+    }
+
+    private suspend fun syncAlbumChannels(context: Context) {
+        val selectedAlbumIds = PreferenceManager.get(CHANNEL_ALBUMS)
+        val existingAlbumChannels = queryAlbumChannels(context)
+
+        // channels for albums the user deselected since the last sync
+        existingAlbumChannels
+            .filterKeys { it !in selectedAlbumIds }
+            .values
+            .forEach { deleteChannel(context, it.id) }
+
+        if (selectedAlbumIds.isEmpty()) {
+            return
+        }
+
+        val apiClient = ApiClient.getClient(ApiClientConfig.fromPrefs())
+        val albums = apiClient.listAlbums().getOrElse {
+            Timber.w("Could not load albums for home screen channels: $it")
+            return
+        }
+
+        selectedAlbumIds.forEach { albumId ->
+            // only sync programs for a channel the foreground picker already created + had
+            // approved - the background sync never creates one itself, see
+            // [createAlbumChannelAndRequestApproval]
+            val channel = existingAlbumChannels[albumId] ?: return@forEach
+            val album = albums.find { it.id == albumId } ?: return@forEach
+            val assets = apiClient.listAssets(
+                page = 1,
+                pageCount = MAX_PROGRAMS_PER_CHANNEL,
+                random = false,
+                order = "desc",
+                contentType = ContentType.ALL,
+                albumIds = listOf(albumId)
+            ).getOrElse {
+                Timber.w("Could not load assets for album channel $albumId: $it")
+                return@forEach
+            }.assets
+
+            syncProgramsForChannel(context, albumChannelInternalId(albumId), channel.id, assets)
+            // keep the channel name in sync with the album name, in case it was renamed
+            if (channel.displayName != album.albumName) {
+                val updated = Channel.Builder(channel).setDisplayName(album.albumName).build()
+                context.contentResolver.update(TvContractCompat.buildChannelUri(channel.id), updated.toContentValues(), null, null)
+            }
+        }
+    }
+
+    private fun requestChannelApproval(activity: Activity, channelId: Long) {
+        val intent = Intent(TvContractCompat.ACTION_REQUEST_CHANNEL_BROWSABLE)
+        intent.putExtra(TvContractCompat.EXTRA_CHANNEL_ID, channelId)
+        try {
+            @Suppress("DEPRECATION")
+            activity.startActivityForResult(intent, REQUEST_CHANNEL_BROWSABLE)
+        } catch (e: ActivityNotFoundException) {
+            Timber.w(e, "Device does not support the channel approval dialog")
+        }
+    }
+
+    private fun createChannel(context: Context, internalProviderId: String, displayName: String, appLinkUri: Uri, requestBrowsable: Boolean): Long {
+        val channel = Channel.Builder()
+            .setType(TvContractCompat.Channels.TYPE_PREVIEW)
+            .setDisplayName(displayName)
+            .setAppLinkIntentUri(appLinkUri)
+            .setInternalProviderId(internalProviderId)
+            .build()
+        val channelUri = context.contentResolver.insert(TvContractCompat.Channels.CONTENT_URI, channel.toContentValues())
+            ?: error("Could not insert home screen channel into TvProvider")
+        val channelId = ContentUris.parseId(channelUri)
+
+        // 80dp x 80dp opaque logo, displayed under a circular mask
+        BitmapFactory.decodeResource(context.resources, R.drawable.icon_600px)?.let { logo ->
+            ChannelLogoUtils.storeChannelLogo(context, channelId, logo)
+        }
+
+        if (requestBrowsable) {
+            // only guaranteed to be auto-approved for the very first channel the app creates
+            TvContractCompat.requestChannelBrowsable(context, channelId)
+        }
+        return channelId
+    }
+
+    /**
+     * Every channel this app currently owns in the TvProvider. Deliberately queries with no
+     * `selection` and filters client-side - at least one real device (Sony Bravia/Google TV)
+     * throws `SecurityException: Selection not allowed for content://android.media.tv/channel`
+     * for any non-null selection on this URI, even one scoped to this app's own rows.
+     */
+    private fun queryAllChannels(context: Context): List<Channel> {
+        val channels = mutableListOf<Channel>()
+        context.contentResolver.query(TvContractCompat.Channels.CONTENT_URI, null, null, null, null)?.use { cursor ->
+            while (cursor.moveToNext()) {
+                channels.add(Channel.fromCursor(cursor))
+            }
+        }
+        return channels
+    }
+
+    private fun findChannel(context: Context, internalProviderId: String): Channel? =
+        queryAllChannels(context).find { it.internalProviderId == internalProviderId }
+
+    /** Every album channel this app currently owns in the TvProvider, keyed by album id. */
+    private fun queryAlbumChannels(context: Context): Map<String, Channel> {
+        return queryAllChannels(context)
+            .mapNotNull { channel -> channel.internalProviderId?.let { it to channel } }
+            .filter { (internalId, _) -> internalId.startsWith(ALBUM_CHANNEL_INTERNAL_ID_PREFIX) }
+            .associate { (internalId, channel) -> albumIdFromChannelInternalId(internalId) to channel }
+    }
+
+    private fun deleteChannel(context: Context, channelId: Long) {
+        context.contentResolver.delete(TvContractCompat.buildChannelUri(channelId), null, null)
+    }
+
+    /** Deletes every channel this app owns - not just ones this process remembers creating. */
+    private fun deleteAllChannels(context: Context) {
+        queryAllChannels(context).forEach { channel -> deleteChannel(context, channel.id) }
+    }
+
+    /**
+     * Diffs [assets] against the programs the provider currently has for [channelId] - not just
+     * our local state - so a card the user removed (browsable-disabled) or a whole channel the
+     * user cleared out is respected rather than silently overwritten. Assets already present are
+     * updated in place (poster art URL - and the API key embedded in it - title, and weight can
+     * all change between syncs), not just left stale.
+     */
+    private fun syncProgramsForChannel(context: Context, channelInternalId: String, channelId: Long, assets: List<Asset>) {
+        val resolver = context.contentResolver
+        val existingProgramIdsByAssetId = mutableMapOf<String, Long>()
+        resolver.query(TvContractCompat.buildPreviewProgramsUriForChannel(channelId), null, null, null, null)?.use { cursor ->
+            while (cursor.moveToNext()) {
+                val program = PreviewProgram.fromCursor(cursor)
+                program.internalProviderId?.let { assetId -> existingProgramIdsByAssetId[assetId] = program.id }
+            }
+        }
+
+        val excludedAssetIds = ChannelRegistryStore.excludedAssetIds(channelInternalId)
+        val targetAssetIds = assets.map { it.id }.filterNot { excludedAssetIds.contains(it) }.toSet()
+
+        existingProgramIdsByAssetId
+            .filterKeys { it !in targetAssetIds }
+            .values
+            .forEach { programId -> resolver.delete(TvContractCompat.buildPreviewProgramUri(programId), null, null) }
+
+        assets.forEachIndexed { index, asset ->
+            if (asset.id !in targetAssetIds) {
+                return@forEachIndexed
+            }
+            val posterArtUrl = ApiUtil.getThumbnailUrl(asset.id, "preview", includeApiKey = true) ?: return@forEachIndexed
+            val program = PreviewProgram.Builder()
+                .setChannelId(channelId)
+                .setType(TvContractCompat.PreviewPrograms.TYPE_CLIP)
+                .setTitle(asset.originalFileName ?: asset.id)
+                .setPosterArtUri(Uri.parse(posterArtUrl))
+                .setPosterArtAspectRatio(TvContractCompat.PreviewPrograms.ASPECT_RATIO_16_9)
+                .setIntentUri(ChannelDeepLinks.forAsset(asset.id))
+                .setInternalProviderId(asset.id)
+                .setWeight(assets.size - index)
+                .build()
+
+            val existingProgramId = existingProgramIdsByAssetId[asset.id]
+            if (existingProgramId != null) {
+                resolver.update(TvContractCompat.buildPreviewProgramUri(existingProgramId), program.toContentValues(), null, null)
+            } else {
+                resolver.insert(TvContractCompat.PreviewPrograms.CONTENT_URI, program.toContentValues())
+            }
+        }
+    }
+}

--- a/app/src/main/java/nl/giejay/android/tv/immich/homescreenchannels/HomeScreenChannelReceiver.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/homescreenchannels/HomeScreenChannelReceiver.kt
@@ -1,0 +1,83 @@
+package nl.giejay.android.tv.immich.homescreenchannels
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.tvprovider.media.tv.Channel
+import androidx.tvprovider.media.tv.PreviewProgram
+import androidx.tvprovider.media.tv.TvContractCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Handles the two broadcasts the platform sends this app about home screen channels:
+ * - INITIALIZE_PROGRAMS: sent once after install, before the user has opened the app. Runs the
+ *   same [HomeScreenChannelManager.syncAll] as every other trigger (so it also honours the
+ *   enable pref and requires the user already be logged in - on a genuinely fresh install
+ *   neither is true yet, so this is mostly useful when the launcher re-sends the broadcast
+ *   later, e.g. after an app update). Album channels aren't created here regardless, since
+ *   approving a non-default channel requires the app in the foreground (see
+ *   [HomeScreenChannelManager.createAlbumChannelAndRequestApproval]).
+ * - PREVIEW_PROGRAM_BROWSABLE_DISABLED: sent when the user removes one card from the launcher's
+ *   own UI. The platform contract requires deleting the row and never reinserting it.
+ */
+class HomeScreenChannelReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            TvContractCompat.ACTION_INITIALIZE_PROGRAMS -> handleInitializePrograms(context)
+            TvContractCompat.ACTION_PREVIEW_PROGRAM_BROWSABLE_DISABLED -> handleProgramBrowsableDisabled(context, intent)
+        }
+    }
+
+    private fun handleInitializePrograms(context: Context) {
+        val appContext = context.applicationContext
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                HomeScreenChannelManager.syncAll(appContext)
+            } catch (e: Exception) {
+                Timber.e(e, "Could not initialize home screen channels")
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private fun handleProgramBrowsableDisabled(context: Context, intent: Intent) {
+        val programId = intent.getLongExtra(TvContractCompat.EXTRA_PREVIEW_PROGRAM_ID, -1L)
+        if (programId < 0) return
+        val appContext = context.applicationContext
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                removeDisabledProgram(appContext, programId)
+            } catch (e: Exception) {
+                Timber.e(e, "Could not process disabled preview program $programId")
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private fun removeDisabledProgram(context: Context, programId: Long) {
+        val resolver = context.contentResolver
+        val programUri = TvContractCompat.buildPreviewProgramUri(programId)
+        resolver.query(programUri, null, null, null, null)?.use { cursor ->
+            if (!cursor.moveToFirst()) return@use
+            val program = PreviewProgram.fromCursor(cursor)
+            // the system is the only legitimate sender of this broadcast, but the receiver is
+            // necessarily exported - a spoofed broadcast can at most make us exclude one of our
+            // own already-hidden rows, never anyone else's data, but check the row actually is
+            // hidden before acting on it anyway
+            if (program.isBrowsable) return@use
+            val assetId = program.internalProviderId ?: return@use
+            val channelInternalId = resolver.query(TvContractCompat.buildChannelUri(program.channelId), null, null, null, null)
+                ?.use { channelCursor -> if (channelCursor.moveToFirst()) Channel.fromCursor(channelCursor).internalProviderId else null }
+                ?: return@use
+            ChannelRegistryStore.addExcludedAssetId(channelInternalId, assetId)
+        }
+        resolver.delete(programUri, null, null)
+    }
+}

--- a/app/src/main/java/nl/giejay/android/tv/immich/settings/SettingsFragment.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/settings/SettingsFragment.kt
@@ -15,6 +15,7 @@ import nl.giejay.android.tv.immich.home.HomeFragmentDirections
 import nl.giejay.android.tv.immich.screensaver.ScreenSaverType
 import nl.giejay.android.tv.immich.shared.donate.DonateService
 import nl.giejay.android.tv.immich.shared.prefs.DebugPrefScreen
+import nl.giejay.android.tv.immich.shared.prefs.HomeScreenChannelsPrefScreen
 import nl.giejay.android.tv.immich.shared.prefs.PreferenceManager
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_ALBUMS
 import nl.giejay.android.tv.immich.shared.prefs.SCREENSAVER_TYPE
@@ -103,6 +104,17 @@ class SettingsFragment : RowsSupportFragment() {
                                     HomeFragmentDirections.actionGlobalScreensaverPreview()
                                 )
                             }
+                        },
+                        SettingsCard(
+                            ImmichApplication.appContext!!.getString(R.string.home_screen_channels),
+                            null,
+                            "home_screen_channels",
+                            "ic_settings_settings",
+                            "ic_settings_settings"
+                        ) {
+                            findNavController().navigate(
+                                HomeFragmentDirections.actionGlobalToSettingsDialog(HomeScreenChannelsPrefScreen.key)
+                            )
                         },
                         SettingsCard(
                             ImmichApplication.appContext!!.getString(R.string.debug),

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
@@ -19,6 +19,7 @@ import nl.giejay.android.tv.immich.ImmichApplication
 import nl.giejay.android.tv.immich.R
 import nl.giejay.android.tv.immich.album.AlbumFragmentDirections
 import nl.giejay.android.tv.immich.album.SelectionType
+import nl.giejay.android.tv.immich.homescreenchannels.HomeScreenChannelManager
 import nl.giejay.android.tv.immich.screensaver.ScreenSaverType
 import nl.giejay.mediaslider.transformations.GlideTransformations
 
@@ -170,6 +171,33 @@ data object SCREENSAVER_TYPE : EnumByTitlePref<ScreenSaverType>(ScreenSaverType.
         return ScreenSaverType.entries.toTypedArray()
     }
 }
+
+// home screen channels
+data object ENABLE_HOME_SCREEN_CHANNELS : BooleanPref(true,
+    ImmichApplication.appContext!!.getString(R.string.enable_home_screen_channels),
+    ImmichApplication.appContext!!.getString(R.string.enable_home_screen_channels_desc))
+
+data object CHANNEL_ALBUMS : StringSetPref(mutableSetOf(),
+    ImmichApplication.appContext!!.getString(R.string.set_albums_home_screen_channels),
+    ImmichApplication.appContext!!.getString(R.string.set_albums_home_screen_channels_desc)) {
+    override fun onClick(context: Context, controller: NavController): Boolean {
+        controller.navigate(
+            AlbumFragmentDirections.actionGlobalAlbumFragment(
+                true,
+                SelectionType.SET_CHANNEL_ALBUMS.toString(),
+                "home_screen_channels"
+            )
+        )
+        return true
+    }
+}
+
+data object CHANNEL_REFRESH_NOW : ActionPref(null, ImmichApplication.appContext!!.getString(R.string.home_screen_channels_refresh_now),
+    ImmichApplication.appContext!!.getString(R.string.home_screen_channels_refresh_now_desc),
+    { _, _ ->
+        HomeScreenChannelManager.scheduleRefresh("manual")
+        true
+    })
 
 // slider/viewer
 data object SLIDER_INTERVAL : IntListPref(6,
@@ -567,6 +595,17 @@ data object ScreensaverPrefScreen : PrefScreen(ImmichApplication.appContext!!.ge
                 SCREENSAVER_INCLUDE_VIDEOS,
                 SCREENSAVER_PLAY_SOUND,
                 SCREENSAVER_ANIMATE_ASSET_SLIDE)
+        )
+    )
+)
+
+data object HomeScreenChannelsPrefScreen : PrefScreen(ImmichApplication.appContext!!.getString(R.string.home_screen_channels_settings), "home_screen_channels",
+    listOf(
+        PrefCategory("",
+            listOf(
+                ENABLE_HOME_SCREEN_CHANNELS,
+                CHANNEL_ALBUMS,
+                CHANNEL_REFRESH_NOW)
         )
     )
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,6 +209,18 @@
     <string name="settings_for">Settings for %1$s</string>
     <string name="filtering">Filtering</string>
 
+    <!-- Home screen channels -->
+    <string name="home_screen_channels">Home screen channels</string>
+    <string name="home_screen_channels_settings">Home screen channel settings</string>
+    <string name="channel_recent_photos">Recent photos</string>
+    <string name="enable_home_screen_channels">Show channels on home screen</string>
+    <string name="enable_home_screen_channels_desc">Publish your recent photos, and any albums you pick below, as channels on the Android TV home screen</string>
+    <string name="set_albums_home_screen_channels">Set albums to publish as channels</string>
+    <string name="set_albums_home_screen_channels_desc">Each selected album shows up as its own row on the Android TV home screen</string>
+    <string name="home_screen_channels_refresh_now">Refresh now</string>
+    <string name="home_screen_channels_refresh_now_desc">Immediately sync the home screen channels instead of waiting for the next automatic refresh</string>
+    <string name="home_screen_channel_error">Could not set up the home screen channel for this album</string>
+
     <!-- Auth step 1 -->
     <string name="auth_sign_in_by_api_key">Sign in by API key</string>
     <string name="auth_sign_in_by_api_key_desc">Login to your Immich instance by entering your API key.</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ rxjava = "3.1.12"
 test = "1.7.0"
 timber = "5.0.1"
 truth = "1.4.5"
+tvprovider = "1.1.0"
 
 [libraries]
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
@@ -66,6 +67,7 @@ androidx-navigation-safe-args-gradle-plugin = { group = "androidx.navigation", n
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigation" }
 androidx-rules = { group = "androidx.test", name = "rules", version.ref = "test" }
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "test" }
+androidx-tvprovider = { group = "androidx.tvprovider", name = "tvprovider", version.ref = "tvprovider" }
 arrow-core = { group = "io.arrow-kt", name = "arrow-core", version.ref = "arrow-core" }
 billing-ktx = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "billing-ktx" }
 converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit2" }


### PR DESCRIPTION
- Publishes Immich photos to the TV launcher's home screen using Android's home screen channels API: a "Recent photos" row, plus one row per album picked in a new settings screen.
- Tapping a card deep-links into the app to that asset, album, or home.
- Respects the platform's own sync/removal broadcasts, so a card the user removes from the launcher stays removed.
- Requires Android TV 8.0 (API 26) or newer.