### PR TITLE
Encrypt the stored Immich API key

### DIFF
--- a/app/src/main/java/nl/giejay/android/tv/immich/security/ApiKeyCipher.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/security/ApiKeyCipher.kt
@@ -1,0 +1,100 @@
+package nl.giejay.android.tv.immich.security
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import timber.log.Timber
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+private const val KEY_ALIAS = "immich_api_key"
+private const val TRANSFORMATION = "AES/GCM/NoPadding"
+private const val GCM_TAG_LENGTH_BITS = 128
+private const val GCM_IV_LENGTH_BYTES = 12
+private const val VERSION_PREFIX = "v1:"
+// accepted tradeoff: on the rare broken-keystore path this plaintext fallback is still subject
+// to whatever backup config the app has (currently none excludes it)
+private const val PLAINTEXT_FALLBACK_PREFIX = "plain:"
+
+/**
+ * Encrypts the Immich API key with a key that never leaves AndroidKeyStore.
+ * `security-crypto`/EncryptedSharedPreferences is deprecated since 1.1.0-beta01 in favor of this.
+ */
+object ApiKeyCipher {
+
+    // Never throws: falls back to a tagged plaintext form on a broken keystore instead of
+    // crashing app startup. Self-heals - retried on every subsequent save.
+    fun encrypt(plaintext: String): String {
+        if (plaintext.isEmpty()) return ""
+        return try {
+            val cipher = Cipher.getInstance(TRANSFORMATION).apply { init(Cipher.ENCRYPT_MODE, getOrCreateKey()) }
+            val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+            VERSION_PREFIX + Base64.encodeToString(cipher.iv + ciphertext, Base64.NO_WRAP)
+        } catch (e: Exception) {
+            Timber.e(e, "Could not encrypt API key, falling back to unencrypted storage for now")
+            PLAINTEXT_FALLBACK_PREFIX + plaintext
+        }
+    }
+
+    // Never throws: an unrecognized/corrupt value degrades to "" (logged out). A value from
+    // before encryption existed has no prefix at all, so it's returned as-is for the caller to
+    // re-save (migrate).
+    fun decryptOrAdoptLegacy(stored: String): String {
+        return when {
+            stored.isEmpty() -> ""
+            stored.startsWith(PLAINTEXT_FALLBACK_PREFIX) -> stored.removePrefix(PLAINTEXT_FALLBACK_PREFIX)
+            stored.startsWith(VERSION_PREFIX) -> decrypt(stored.removePrefix(VERSION_PREFIX))
+            else -> stored
+        }
+    }
+
+    /** True if [stored] already went through [encrypt] (vs. legacy/fallback plaintext). */
+    fun isEncrypted(stored: String): Boolean = stored.startsWith(VERSION_PREFIX)
+
+    private fun decrypt(base64: String): String {
+        // no key at all (keystore wiped/restored elsewhere) is an expected, silent logout -
+        // not an error, and mustn't generate a fresh unusable key as a side effect of reading
+        val key = getExistingKey() ?: return ""
+        val combined = try {
+            Base64.decode(base64, Base64.NO_WRAP)
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+        // size check guards copyOfRange below against corrupted/truncated input
+        return combined?.takeIf { it.size > GCM_IV_LENGTH_BYTES }?.let { bytes ->
+            try {
+                val iv = bytes.copyOfRange(0, GCM_IV_LENGTH_BYTES)
+                val encrypted = bytes.copyOfRange(GCM_IV_LENGTH_BYTES, bytes.size)
+                val cipher = Cipher.getInstance(TRANSFORMATION).apply {
+                    init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv))
+                }
+                String(cipher.doFinal(encrypted), Charsets.UTF_8)
+            } catch (e: Exception) {
+                Timber.e(e, "Could not decrypt stored API key; treating as logged out")
+                null
+            }
+        } ?: ""
+    }
+
+    @Synchronized
+    private fun getExistingKey(): SecretKey? {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        return keyStore.getKey(KEY_ALIAS, null) as? SecretKey
+    }
+
+    @Synchronized
+    private fun getOrCreateKey(): SecretKey = getExistingKey() ?: run {
+        val spec = KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            .build()
+        KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+            .apply { init(spec) }
+            .generateKey()
+    }
+}

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/CustomGlideModule.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/CustomGlideModule.kt
@@ -28,7 +28,7 @@ class CustomGlideModule : AppGlideModule() {
         prefs.listenMultiple(listOf(API_KEY.key(), DEBUG_MODE.key(), DISABLE_SSL_VERIFICATION.key()))
             .observeForever {
                 reloadFactory(
-                    it[API_KEY.key()] as String,
+                    PreferenceManager.get(API_KEY), // listenMultiple's raw value is still encrypted
                     it[DISABLE_SSL_VERIFICATION.key()] == true
                 )
             }

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/PreferenceManager.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/PreferenceManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.CoroutineScope
+import nl.giejay.android.tv.immich.security.ApiKeyCipher
 import nl.giejay.android.tv.immich.slider.FavoriteButtonControllerPlugin
 import nl.giejay.android.tv.immich.slider.FavoriteService
 import nl.giejay.mediaslider.adapter.AlignOption
@@ -49,11 +50,21 @@ object PreferenceManager {
     fun init(context: Context) {
         sharedPreference = PreferenceManager.getDefaultSharedPreferences(context)
         liveSharedPreferences = LiveSharedPreferences(sharedPreference)
+        migrateApiKeyIfNeeded()
         subclasses(Pref::class).filter { it.objectInstance != null }.forEach { pref ->
             val prefInstance = pref.objectInstance!! as Pref<Any, *, *>
             liveSharedPreferences.subscribeTyped(prefInstance) { typeValue ->
                 liveContext[prefInstance.key()] = typeValue
             }
+        }
+    }
+
+    // one-time, before the subscription loop below reads it: re-save a legacy-plaintext or
+    // previously-unencryptable API key now that ApiKeyCipher can (re)try encrypting it
+    private fun migrateApiKeyIfNeeded() {
+        val raw = sharedPreference.getString(API_KEY.key(), "") ?: return
+        if (raw.isNotEmpty() && !ApiKeyCipher.isEncrypted(raw)) {
+            API_KEY.save(sharedPreference, ApiKeyCipher.decryptOrAdoptLegacy(raw))
         }
     }
 

--- a/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
+++ b/app/src/main/java/nl/giejay/android/tv/immich/shared/prefs/Preferences.kt
@@ -20,6 +20,7 @@ import nl.giejay.android.tv.immich.R
 import nl.giejay.android.tv.immich.album.AlbumFragmentDirections
 import nl.giejay.android.tv.immich.album.SelectionType
 import nl.giejay.android.tv.immich.screensaver.ScreenSaverType
+import nl.giejay.android.tv.immich.security.ApiKeyCipher
 import nl.giejay.mediaslider.transformations.GlideTransformations
 
 // general
@@ -33,6 +34,21 @@ data object API_KEY : StringPref("",
     ImmichApplication.appContext!!.getString(R.string.api_key_text),
     ImmichApplication.appContext!!.getString(R.string.api_key_text)) {
     override fun key() = "apiKey"
+
+    // Encrypted at rest via ApiKeyCipher; fromPrefValue also needs the override since
+    // PreferenceManager's eager subscription reads raw values through it, bypassing getValue().
+    // Legacy-plaintext migration happens once in PreferenceManager.init(), not here - this stays
+    // a pure decrypt so it's safe to call from a reactive callback.
+    override fun getValue(sharedPreferences: SharedPreferences): String =
+        fromPrefValue(sharedPreferences.getString(key(), defaultValue) ?: defaultValue)
+
+    override fun fromPrefValue(prefValue: String): String = ApiKeyCipher.decryptOrAdoptLegacy(prefValue)
+
+    override fun save(sharedPreferences: SharedPreferences, value: String) {
+        sharedPreferences.edit().putString(key(), toPrefValue(value)).apply()
+    }
+
+    override fun toPrefValue(value: String): String = ApiKeyCipher.encrypt(value)
 }
 
 data object HOST_NAME : StringPref("",

--- a/app/src/test/java/nl/giejay/android/tv/immich/security/ApiKeyCipherTest.kt
+++ b/app/src/test/java/nl/giejay/android/tv/immich/security/ApiKeyCipherTest.kt
@@ -1,0 +1,33 @@
+package nl.giejay.android.tv.immich.security
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// Covers the pure migration/prefix logic only - the AES-GCM round trip needs a real
+// AndroidKeyStore, unavailable under plain JVM unit tests.
+class ApiKeyCipherTest {
+
+    @Test
+    fun `empty value decrypts to empty without touching the keystore`() {
+        assertEquals("", ApiKeyCipher.decryptOrAdoptLegacy(""))
+    }
+
+    @Test
+    fun `unprefixed value is treated as a legacy plaintext key`() {
+        assertEquals("legacy-plaintext-key", ApiKeyCipher.decryptOrAdoptLegacy("legacy-plaintext-key"))
+        assertFalse(ApiKeyCipher.isEncrypted("legacy-plaintext-key"))
+    }
+
+    @Test
+    fun `plaintext fallback prefix is stripped without touching the keystore`() {
+        assertEquals("fallback-key", ApiKeyCipher.decryptOrAdoptLegacy("plain:fallback-key"))
+        assertFalse(ApiKeyCipher.isEncrypted("plain:fallback-key"))
+    }
+
+    @Test
+    fun `versioned value is recognized as already encrypted`() {
+        assertTrue(ApiKeyCipher.isEncrypted("v1:whatever-ciphertext"))
+    }
+}


### PR DESCRIPTION
- The API key (full read/download access to the library) was stored as plain text in the app's default settings file, with no encryption and no backup protections.
- Now encrypted at rest with a key that lives entirely in Android's Keystore and never leaves it, so only unreadable ciphertext is ever persisted, even in a backup or on a rooted device.
- No new dependency needed. Google [deprecated](https://developer.android.com/jetpack/androidx/releases/security) the usual `androidx.security-crypto` library (`1.1.0-beta01`, June 2025) "in favour of existing platform APIs and direct use of Android Keystore," which is exactly what this does.
- Existing installs migrate automatically on first launch after the update, no re-login needed.
- If a device's keystore is ever unusable, this fails safe: it falls back to a working (if unencrypted) state rather than crashing the app.